### PR TITLE
Localize dashboard cache hint in Chinese

### DIFF
--- a/messages/zh.json
+++ b/messages/zh.json
@@ -176,7 +176,7 @@
   "dashboard_hint_success_rate": "成功率 {rate}",
   "dashboard_hint_error_rate": "错误率 {rate}",
   "dashboard_tokens_hint_no_cache": "输入 {input} · 输出 {output}",
-  "dashboard_tokens_hint_with_cache": "输入 {input}（cached {cached}）· 输出 {output}",
+  "dashboard_tokens_hint_with_cache": "输入 {input}（缓存 {cached}）· 输出 {output}",
   "dashboard_latency_hint": "按请求均值",
   "dashboard_providers_title": "Providers",
   "dashboard_providers_desc": "按 Tokens 排序（Top 10）",


### PR DESCRIPTION
## Summary
- Replace the English word "cached" in the Chinese dashboard token hint with the proper Chinese term "缓存".

## Why
- The dashboard was showing an English word in the Chinese locale, which breaks the i18n experience.

## Implementation details
- Updated the `dashboard_tokens_hint_with_cache` string in `messages/zh.json` to use "缓存" while preserving the existing placeholders.