### PR TITLE
Dashboard: use "今日" for the default date label

### DIFF
--- a/messages/zh.json
+++ b/messages/zh.json
@@ -162,7 +162,7 @@
   "dashboard_truncated": "已截断",
   "dashboard_range_label": "时间范围",
   "dashboard_range_placeholder": "选择范围",
-  "dashboard_range_today": "今天",
+  "dashboard_range_today": "今日",
   "dashboard_range_1h": "最近 1 小时",
   "dashboard_range_24h": "最近 24 小时",
   "dashboard_range_7d": "最近 7 天",


### PR DESCRIPTION
## Summary
- Update the Chinese dashboard date-range label from “今天” to “今日”.

## Why
- The task requested the default dashboard filter copy use “今日” instead of “今天”.

## Implementation details
- Updated `dashboard_range_today` in `messages/zh.json`.
