### PR TITLE
Add configurable inbound request body limit (default 20MB)

### DIFF
--- a/src-tauri/src/proxy/config/mod.rs
+++ b/src-tauri/src/proxy/config/mod.rs
@@ -5,6 +5,8 @@ mod types;
 
 use tauri::AppHandle;
 
+const DEFAULT_MAX_REQUEST_BODY_BYTES: u64 = 20 * 1024 * 1024;
+
 pub(crate) use io::config_dir_path;
 pub(crate) use types::{
     ConfigResponse,
@@ -54,6 +56,7 @@ impl ProxyConfig {
 
 fn build_runtime_config(app: &AppHandle, config: ProxyConfigFile) -> Result<ProxyConfig, String> {
     let log_path = io::resolve_log_path(app, &config.log_path)?;
+    let max_request_body_bytes = resolve_max_request_body_bytes(config.max_request_body_bytes);
     let normalized_upstreams = normalize::normalize_upstreams(&config.upstreams)?;
     let upstreams = normalize::build_provider_upstreams(normalized_upstreams)?;
     Ok(ProxyConfig {
@@ -61,8 +64,19 @@ fn build_runtime_config(app: &AppHandle, config: ProxyConfigFile) -> Result<Prox
         port: config.port,
         local_api_key: config.local_api_key,
         log_path,
+        max_request_body_bytes,
         enable_api_format_conversion: config.enable_api_format_conversion,
         upstream_strategy: config.upstream_strategy,
         upstreams,
     })
+}
+
+fn resolve_max_request_body_bytes(value: Option<u64>) -> usize {
+    let value = value.unwrap_or(DEFAULT_MAX_REQUEST_BODY_BYTES);
+    let value = if value == 0 {
+        DEFAULT_MAX_REQUEST_BODY_BYTES
+    } else {
+        value
+    };
+    usize::try_from(value).unwrap_or(usize::MAX)
 }

--- a/src-tauri/src/proxy/config/types.rs
+++ b/src-tauri/src/proxy/config/types.rs
@@ -87,6 +87,8 @@ pub(crate) struct ProxyConfigFile {
     pub(crate) port: u16,
     pub(crate) local_api_key: Option<String>,
     pub(crate) log_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) max_request_body_bytes: Option<u64>,
     #[serde(default)]
     pub(crate) tray_token_rate: TrayTokenRateConfig,
     /// 是否允许在 OpenAI Chat Completions 与 Responses API 之间自动互转。
@@ -106,6 +108,7 @@ impl Default for ProxyConfigFile {
             port: default_proxy_port(),
             local_api_key: None,
             log_path: "proxy.log".to_string(),
+            max_request_body_bytes: None,
             tray_token_rate: TrayTokenRateConfig::default(),
             enable_api_format_conversion: false,
             upstream_strategy: UpstreamStrategy::PriorityRoundRobin,
@@ -161,6 +164,7 @@ pub(crate) struct ProxyConfig {
     pub(crate) port: u16,
     pub(crate) local_api_key: Option<String>,
     pub(crate) log_path: PathBuf,
+    pub(crate) max_request_body_bytes: usize,
     pub(crate) enable_api_format_conversion: bool,
     pub(crate) upstream_strategy: UpstreamStrategy,
     pub(crate) upstreams: HashMap<String, ProviderUpstreams>,

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -181,10 +181,14 @@ pub(crate) fn build_upstream_cursors(config: &ProxyConfig) -> HashMap<String, Ve
     cursors
 }
 
-pub(crate) fn build_router(state: ProxyStateHandle) -> Router<ProxyStateHandle> {
+pub(crate) fn build_router(
+    state: ProxyStateHandle,
+    max_request_body_bytes: usize,
+) -> Router<ProxyStateHandle> {
     Router::new()
         .route("/{*path}", any(proxy_request))
-        .layer(DefaultBodyLimit::disable())
+        // 限制入站请求体，避免超大请求占用内存/临时盘并拖慢首字节。
+        .layer(DefaultBodyLimit::max(max_request_body_bytes))
         .with_state(state)
 }
 

--- a/src-tauri/src/proxy/service.rs
+++ b/src-tauri/src/proxy/service.rs
@@ -245,6 +245,20 @@ impl ProxyServiceInner {
             );
             return self.restart(app).await;
         }
+        let current_max_request_body_bytes = if let Some(running) = self.running.as_ref() {
+            let guard = running.state_handle.read().await;
+            guard.config.max_request_body_bytes
+        } else {
+            loaded_config.max_request_body_bytes
+        };
+        if loaded_config.max_request_body_bytes != current_max_request_body_bytes {
+            tracing::info!(
+                new_max_request_body_bytes = loaded_config.max_request_body_bytes,
+                current_max_request_body_bytes = current_max_request_body_bytes,
+                "proxy reload detected body limit change, restarting"
+            );
+            return self.restart(app).await;
+        }
 
         let sqlite_pool = self.sqlite_pool.clone();
         let new_state = build_proxy_state(&app, loaded_config, sqlite_pool).await?;
@@ -301,8 +315,12 @@ async fn build_router_state(
     sqlite_pool: Option<SqlitePool>,
 ) -> Result<(ProxyStateHandle, ProxyRouter), String> {
     let state = build_proxy_state(app, config, sqlite_pool).await?;
+    let max_request_body_bytes = state.config.max_request_body_bytes;
     let state_handle = Arc::new(RwLock::new(state));
-    let router = server::build_router(state_handle.clone()).with_state::<()>(state_handle.clone());
+    let router =
+        server::build_router(state_handle.clone(), max_request_body_bytes).with_state::<()>(
+            state_handle.clone(),
+        );
     Ok((state_handle.clone(), router))
 }
 


### PR DESCRIPTION
## Summary
- add optional `max_request_body_bytes` config with a 20MB default
- enforce the limit at the router via `DefaultBodyLimit::max`
- restart the proxy on reload when the body limit changes

## Why
Inbound requests were previously unlimited and fully buffered, which could exhaust memory/temporary disk and significantly increase time-to-first-byte for large uploads.

## Details
- `ProxyConfigFile` now carries `max_request_body_bytes`; missing/0 falls back to the default
- runtime converts the value to `usize` (overflow falls back to `usize::MAX`)
- only the router layer enforces the cap; `ReplayableBody` remains unchanged

## Tests
- not run (not requested)