### PR TITLE
Make proxy logging fire-and-forget to avoid blocking retries

### DIFF
--- a/src-tauri/src/proxy/log.rs
+++ b/src-tauri/src/proxy/log.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 use sqlx::SqlitePool;
 use std::{
     path::PathBuf,
+    sync::Arc,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::{io::AsyncWriteExt, sync::Mutex};
@@ -75,6 +76,13 @@ impl LogWriter {
             file,
             sqlite,
         })
+    }
+
+    // Fire-and-forget logging to avoid blocking the request path.
+    pub(crate) fn write_detached(self: Arc<Self>, entry: LogEntry) {
+        tokio::spawn(async move {
+            self.write(&entry).await;
+        });
     }
 
     pub(crate) async fn write(&self, entry: &LogEntry) {

--- a/src-tauri/src/proxy/response.rs
+++ b/src-tauri/src/proxy/response.rs
@@ -218,7 +218,7 @@ async fn build_buffered_response(
     };
     let usage = extract_usage_from_response(&bytes);
     let entry = build_log_entry(&context, usage);
-    log.write(&entry).await;
+    log.clone().write_detached(entry);
 
     let output = if response_transform != FormatTransform::None && status.is_success() {
         match transform_response_body(response_transform, &bytes, context.model.as_deref()) {

--- a/src-tauri/src/proxy/response/chat_to_responses.rs
+++ b/src-tauri/src/proxy/response/chat_to_responses.rs
@@ -124,7 +124,7 @@ where
                     }
                 }
                 Some(Err(err)) => {
-                    self.log_usage_once().await;
+                    self.log_usage_once();
                     return Err(std::io::Error::new(std::io::ErrorKind::Other, err));
                 }
                 None => {
@@ -141,7 +141,7 @@ where
                     if !self.sent_done {
                         self.push_done();
                     }
-                    self.log_usage_once().await;
+                    self.log_usage_once();
                     if self.out.is_empty() {
                         return Ok(None);
                     }
@@ -569,13 +569,13 @@ where
         self.function_calls.iter().filter(|call| call.is_some()).count() > 1
     }
 
-    async fn log_usage_once(&mut self) {
+    fn log_usage_once(&mut self) {
         if self.logged {
             return;
         }
         self.logged = true;
         let entry = build_log_entry(&self.context, self.collector.finish());
-        self.log.write(&entry).await;
+        self.log.clone().write_detached(entry);
     }
 
     fn next_sequence_number(&mut self) -> u64 {

--- a/src-tauri/src/proxy/response/responses_to_chat.rs
+++ b/src-tauri/src/proxy/response/responses_to_chat.rs
@@ -94,7 +94,7 @@ where
                     }
                 }
                 Some(Err(err)) => {
-                    self.log_usage_once().await;
+                    self.log_usage_once();
                     return Err(std::io::Error::new(std::io::ErrorKind::Other, err));
                 }
                 None => {
@@ -111,7 +111,7 @@ where
                     if !self.sent_done {
                         self.push_done();
                     }
-                    self.log_usage_once().await;
+                    self.log_usage_once();
                     if self.out.is_empty() {
                         return Ok(None);
                     }
@@ -177,13 +177,13 @@ where
         self.out.push_back(Bytes::from("data: [DONE]\n\n"));
     }
 
-    async fn log_usage_once(&mut self) {
+    fn log_usage_once(&mut self) {
         if self.logged {
             return;
         }
         self.logged = true;
         let entry = build_log_entry(&self.context, self.collector.finish());
-        self.log.write(&entry).await;
+        self.log.clone().write_detached(entry);
     }
 }
 

--- a/src-tauri/src/proxy/response/streaming.rs
+++ b/src-tauri/src/proxy/response/streaming.rs
@@ -53,7 +53,7 @@ pub(super) fn stream_with_logging(
                         token_tracker.add_output_text(&text).await;
                     }
                     let entry = build_log_entry(&context, collector.finish());
-                    log.write(&entry).await;
+                    log.clone().write_detached(entry);
                     Err(std::io::Error::new(std::io::ErrorKind::Other, err))
                 }
                 None => {
@@ -68,7 +68,7 @@ pub(super) fn stream_with_logging(
                         token_tracker.add_output_text(&text).await;
                     }
                     let entry = build_log_entry(&context, collector.finish());
-                    log.write(&entry).await;
+                    log.clone().write_detached(entry);
                     Ok(None)
                 }
             }
@@ -134,7 +134,7 @@ where
                 return Ok(Some((next, self)));
             }
             if self.upstream_ended {
-                self.log_usage_once().await;
+                self.log_usage_once();
                 return Ok(None);
             }
 
@@ -155,7 +155,7 @@ where
                     }
                 }
                 Some(Err(err)) => {
-                    self.log_usage_once().await;
+                    self.log_usage_once();
                     return Err(std::io::Error::new(std::io::ErrorKind::Other, err));
                 }
                 None => {
@@ -182,12 +182,12 @@ where
         self.out.push_back(Bytes::from(format!("data: {output}\n\n")));
     }
 
-    async fn log_usage_once(&mut self) {
+    fn log_usage_once(&mut self) {
         if self.logged {
             return;
         }
         let entry = build_log_entry(&self.context, self.collector.finish());
-        self.log.write(&entry).await;
+        self.log.clone().write_detached(entry);
         self.logged = true;
     }
 }


### PR DESCRIPTION
## What changed
- Added a fire-and-forget logging helper and switched request logging to run asynchronously.
- Updated buffered response, SSE streaming, and response-transform paths to avoid awaiting log writes.

## Why
- Upstream retries on 429/5xx were delayed because log writes (including SQLite inserts) were awaited before the retry loop continued.
- This keeps retry latency low and avoids inflating request time on the hot path.

## Implementation details
- Introduced LogWriter::write_detached to spawn background log writes.
- Converted log_usage_once helpers from async to sync and replaced await log.write(...) with write_detached(...) across streaming and conversion flows.
