### PR TITLE
Fix zh dashboard cached-token hint localization

### DIFF
--- a/messages/zh.json
+++ b/messages/zh.json
@@ -176,7 +176,7 @@
   "dashboard_hint_success_rate": "成功率 {rate}",
   "dashboard_hint_error_rate": "错误率 {rate}",
   "dashboard_tokens_hint_no_cache": "输入 {input} · 输出 {output}",
-  "dashboard_tokens_hint_with_cache": "输入 {input}（cached {cached}）· 输出 {output}",
+  "dashboard_tokens_hint_with_cache": "输入 {input}（缓存 {cached}）· 输出 {output}",
   "dashboard_latency_hint": "按请求均值",
   "dashboard_providers_title": "Providers",
   "dashboard_providers_desc": "按 Tokens 排序（Top 10）",


### PR DESCRIPTION
## Summary
- Replace the remaining English "cached" string in the Chinese dashboard token hint with localized "缓存".

## Why
- The task was to fix the dashboard cached i18n; the zh hint still showed English "cached", inconsistent with other cached labels.

## Details
- Update `messages/zh.json` key `dashboard_tokens_hint_with_cache` and keep placeholders intact.

## Testing
- Not run (not requested).