### PR TITLE
fix(dashboard): default time range to today

### DIFF
--- a/src/features/dashboard/DashboardPanel.tsx
+++ b/src/features/dashboard/DashboardPanel.tsx
@@ -57,7 +57,7 @@ function usePagination(totalRequests: number) {
 }
 
 function useDashboardSnapshot() {
-  const [rangePreset, setRangePreset] = useState<DashboardTimeRange>("30d")
+  const [rangePreset, setRangePreset] = useState<DashboardTimeRange>("today")
   const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null)
   const [status, setStatus] = useState<DashboardStatus>("idle")
   const [statusMessage, setStatusMessage] = useState("")


### PR DESCRIPTION
## Summary
- Default the dashboard time filter to "today".

## Why
- The dashboard should open with today's data by default per the task request.

## Details
- Initialize `rangePreset` in `useDashboardSnapshot` to "today" (was "30d").
- No changes to range mapping, snapshot reads, or pagination behavior.
