### PR TITLE
Fix dashboard timestamp formatting in charts and recent requests

### DIFF
--- a/src/components/chart-area-interactive.tsx
+++ b/src/components/chart-area-interactive.tsx
@@ -47,8 +47,54 @@ type ChartBodyProps = {
   range: DashboardTimeRange
 }
 
-function formatTick(value: number, range: DashboardTimeRange) {
-  const date = new Date(value)
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function resolveTimestampMs(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === "string") {
+    const numeric = Number(value)
+    if (Number.isFinite(numeric)) {
+      return numeric
+    }
+    const parsed = Date.parse(value)
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+  }
+  return null
+}
+
+function resolveTooltipTimestamp(payload: unknown) {
+  if (!Array.isArray(payload) || payload.length === 0) {
+    return null
+  }
+  const first = payload[0]
+  if (!isRecord(first)) {
+    return null
+  }
+  const inner = first.payload
+  if (!isRecord(inner)) {
+    return null
+  }
+  // Recharts tooltip label 可能缺失或被格式化，优先使用原始 payload 的时间戳。
+  return resolveTimestampMs(inner.tsMs)
+}
+
+function formatTick(value: unknown, range: DashboardTimeRange) {
+  const tsMs = resolveTimestampMs(value)
+  if (tsMs === null) {
+    return "—"
+  }
+
+  const date = new Date(tsMs)
+  if (Number.isNaN(date.getTime())) {
+    return "—"
+  }
+
   if (range === "today") {
     return date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
   }
@@ -90,13 +136,15 @@ function ChartCanvas({ data, range }: ChartBodyProps) {
           axisLine={false}
           tickMargin={8}
           minTickGap={24}
-          tickFormatter={(value) => formatTick(Number(value), range)}
+          tickFormatter={(value) => formatTick(value, range)}
         />
         <ChartTooltip
           cursor={false}
           content={
             <ChartTooltipContent
-              labelFormatter={(value) => formatTick(Number(value), range)}
+              labelFormatter={(value, payload) =>
+                formatTick(resolveTooltipTimestamp(payload) ?? value, range)
+              }
               formatter={(value, name) => {
                 const label = chartConfig[name as keyof typeof chartConfig]?.label ?? name
                 return (

--- a/src/features/dashboard/RecentRequestsTable.tsx
+++ b/src/features/dashboard/RecentRequestsTable.tsx
@@ -37,13 +37,18 @@ function statusToVariant(status: number): BadgeVariant {
   return "outline";
 }
 
+function formatTimestamp(value: number) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+}
+
 function timeColumn(): ColumnDef<DashboardRequestItem> {
   return {
     id: "time",
     header: m.dashboard_table_time(),
     cell: ({ row }) => (
       <span className="whitespace-nowrap text-xs text-muted-foreground">
-        {new Date(row.original.tsMs).toLocaleString()}
+        {formatTimestamp(row.original.tsMs)}
       </span>
     ),
   };


### PR DESCRIPTION
## Summary
- Harden dashboard time formatting for chart axes/tooltip labels to avoid `Invalid Date`.
- Add a safe fallback for recent request timestamps.

## Why
- The dashboard “Total Tokens” view and recent list can display `Invalid Date` when timestamps are missing, non-numeric, or pre-formatted, which degrades readability.

## Implementation details
- Added timestamp parsing helpers that accept numbers or numeric/date strings and return "—" when invalid.
- Tooltip labels now prefer the original `tsMs` from the payload when the label is formatted/absent.
- Recent requests table renders "—" for invalid timestamps instead of a broken date string.

## Testing
- Not run (suggest `npx tsc --noEmit`, then `npm run dev` to verify the dashboard UI).
