### PR TITLE
Proxy: retry 403 responses to trigger fallback

### DIFF
--- a/src-tauri/src/proxy/upstream.rs
+++ b/src-tauri/src/proxy/upstream.rs
@@ -582,8 +582,11 @@ fn is_retryable_error(err: &reqwest::Error) -> bool {
 }
 
 fn is_retryable_status(status: StatusCode) -> bool {
-    // 对齐 new-api 的重试策略：429/307/5xx（排除 504/524）。
-    if status == StatusCode::TOO_MANY_REQUESTS || status == StatusCode::TEMPORARY_REDIRECT {
+    // 对齐 new-api 的重试策略：429/307/5xx（排除 504/524）；额外允许 403 触发 fallback。
+    if status == StatusCode::FORBIDDEN
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status == StatusCode::TEMPORARY_REDIRECT
+    {
         return true;
     }
     if status == StatusCode::GATEWAY_TIMEOUT {

--- a/src-tauri/src/proxy/upstream/tests.rs
+++ b/src-tauri/src/proxy/upstream/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 
 #[test]
 fn retryable_status_matches_new_api_policy() {
+    assert!(is_retryable_status(StatusCode::FORBIDDEN));
     assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
     assert!(is_retryable_status(StatusCode::TEMPORARY_REDIRECT));
     assert!(is_retryable_status(StatusCode::INTERNAL_SERVER_ERROR));


### PR DESCRIPTION
## Summary
- Treat HTTP 403 as retryable so the proxy can fall back to the next upstream.
- Update retry policy comment and add a unit test assertion.

## Why
403 often indicates a blocked or insufficient API key. In a multi-upstream setup, it is more reliable to fall back to another upstream instead of failing immediately.

## Implementation details
- Added `StatusCode::FORBIDDEN` to `is_retryable_status` in `src-tauri/src/proxy/upstream.rs`.
- Extended retry policy tests in `src-tauri/src/proxy/upstream/tests.rs`.
