### PR TITLE
Fix Responses→Chat tool calls and content parts

### DIFF
--- a/src-tauri/src/proxy/openai_compat.rs
+++ b/src-tauri/src/proxy/openai_compat.rs
@@ -161,7 +161,7 @@ fn responses_response_to_chat(bytes: &Bytes, model_hint: Option<&str>) -> Result
         return Err("Upstream response must be a JSON object.".to_string());
     };
 
-    let content = extract::extract_responses_output_text(&value).unwrap_or_default();
+    let extracted = extract::extract_responses_output(&value);
     let id = object
         .get("id")
         .and_then(Value::as_str)
@@ -177,6 +177,27 @@ fn responses_response_to_chat(bytes: &Bytes, model_hint: Option<&str>) -> Result
         .get("usage")
         .and_then(|usage| usage::map_usage_responses_to_chat(usage));
 
+    let finish_reason = if extracted.tool_calls.is_empty() {
+        "stop"
+    } else {
+        "tool_calls"
+    };
+
+    let mut message = json!({
+        "role": "assistant",
+        "content": extracted.content
+    });
+    if let Some(parts) = extracted.content_parts {
+        if let Some(message) = message.as_object_mut() {
+            message.insert("content_parts".to_string(), Value::Array(parts));
+        }
+    }
+    if !extracted.tool_calls.is_empty() {
+        if let Some(message) = message.as_object_mut() {
+            message.insert("tool_calls".to_string(), Value::Array(extracted.tool_calls));
+        }
+    }
+
     let output = json!({
         "id": id,
         "object": "chat.completion",
@@ -185,8 +206,8 @@ fn responses_response_to_chat(bytes: &Bytes, model_hint: Option<&str>) -> Result
         "choices": [
             {
                 "index": 0,
-                "message": { "role": "assistant", "content": content },
-                "finish_reason": "stop"
+                "message": message,
+                "finish_reason": finish_reason
             }
         ],
         "usage": usage

--- a/src-tauri/src/proxy/openai_compat/extract.rs
+++ b/src-tauri/src/proxy/openai_compat/extract.rs
@@ -1,10 +1,16 @@
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 
 pub(super) struct ChatToolCall {
     pub(super) item_id: String,
     pub(super) call_id: String,
     pub(super) name: String,
     pub(super) arguments: String,
+}
+
+pub(super) struct ResponsesOutput {
+    pub(super) content: String,
+    pub(super) content_parts: Option<Vec<Value>>,
+    pub(super) tool_calls: Vec<Value>,
 }
 
 pub(super) fn extract_chat_choice_text(value: &Value) -> Option<String> {
@@ -89,37 +95,90 @@ fn extract_chat_message_legacy_function_call(function_call: &Map<String, Value>)
     })
 }
 
-pub(super) fn extract_responses_output_text(value: &Value) -> Option<String> {
-    let output = value.get("output")?.as_array()?;
+pub(super) fn extract_responses_output(value: &Value) -> ResponsesOutput {
+    let Some(output) = value.get("output").and_then(Value::as_array) else {
+        return ResponsesOutput {
+            content: String::new(),
+            content_parts: None,
+            tool_calls: Vec::new(),
+        };
+    };
+
     let mut combined = String::new();
+    let mut content_parts = Vec::new();
+    let mut has_non_text = false;
+    let mut tool_calls = Vec::new();
+
     for item in output {
         let Some(item) = item.as_object() else {
             continue;
         };
-        if item.get("type").and_then(Value::as_str) != Some("message") {
-            continue;
-        }
-        if item.get("role").and_then(Value::as_str) != Some("assistant") {
-            continue;
-        }
-        let Some(content) = item.get("content").and_then(Value::as_array) else {
-            continue;
-        };
-        for part in content {
-            let Some(part) = part.as_object() else {
-                continue;
-            };
-            if part.get("type").and_then(Value::as_str) != Some("output_text") {
-                continue;
+        match item.get("type").and_then(Value::as_str) {
+            Some("message") => {
+                if item.get("role").and_then(Value::as_str) != Some("assistant") {
+                    continue;
+                }
+                let Some(content) = item.get("content").and_then(Value::as_array) else {
+                    continue;
+                };
+                for part in content {
+                    if let Some(part_obj) = part.as_object() {
+                        let part_type = part_obj.get("type").and_then(Value::as_str);
+                        if part_type != Some("output_text") {
+                            has_non_text = true;
+                        }
+                        if part_type == Some("output_text") {
+                            if let Some(text) = part_obj.get("text").and_then(Value::as_str) {
+                                combined.push_str(text);
+                            }
+                        }
+                    }
+                    content_parts.push(part.clone());
+                }
             }
-            if let Some(text) = part.get("text").and_then(Value::as_str) {
-                combined.push_str(text);
+            Some("function_call") => {
+                if let Some(tool_call) = extract_responses_tool_call(item) {
+                    tool_calls.push(tool_call);
+                }
             }
+            _ => {}
         }
     }
-    if combined.is_empty() {
-        None
+
+    let content_parts = if has_non_text {
+        Some(content_parts)
     } else {
-        Some(combined)
+        None
+    };
+
+    ResponsesOutput {
+        content: combined,
+        content_parts,
+        tool_calls,
     }
+}
+
+fn extract_responses_tool_call(item: &Map<String, Value>) -> Option<Value> {
+    let call_id = item.get("call_id").and_then(Value::as_str).unwrap_or("");
+    let item_id = item.get("id").and_then(Value::as_str).unwrap_or("");
+    let name = item.get("name").and_then(Value::as_str).unwrap_or("");
+    let arguments = item.get("arguments").and_then(Value::as_str).unwrap_or("");
+    let id = if !call_id.is_empty() {
+        call_id.to_string()
+    } else if !item_id.is_empty() {
+        item_id.to_string()
+    } else {
+        "call_proxy".to_string()
+    };
+    if name.is_empty() && arguments.is_empty() && id == "call_proxy" {
+        return None;
+    }
+    Some(json!({
+        "id": id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments
+        }
+    }))
 }

--- a/src-tauri/src/proxy/openai_compat/tests.rs
+++ b/src-tauri/src/proxy/openai_compat/tests.rs
@@ -200,9 +200,49 @@ fn responses_response_to_chat_extracts_output_text_and_maps_usage() {
     assert_eq!(value["model"], json!("gpt-4.1"));
     assert_eq!(value["choices"][0]["message"]["role"], json!("assistant"));
     assert_eq!(value["choices"][0]["message"]["content"], json!("Hello world"));
+    assert_eq!(value["choices"][0]["finish_reason"], json!("stop"));
     assert_eq!(value["usage"]["prompt_tokens"], json!(1));
     assert_eq!(value["usage"]["completion_tokens"], json!(2));
     assert_eq!(value["usage"]["total_tokens"], json!(3));
+}
+
+#[test]
+fn responses_response_to_chat_includes_tool_calls_and_content_parts() {
+    let input = bytes_from_json(json!({
+        "id": "resp_456",
+        "created_at": 1700000001,
+        "model": "gpt-4.1",
+        "output": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    { "type": "output_text", "text": "Hello", "annotations": [] },
+                    { "type": "output_image", "image_url": { "url": "https://example.com/a.png" } }
+                ]
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_foo",
+                "name": "doThing",
+                "arguments": "{\"a\":1}"
+            }
+        ],
+        "usage": { "input_tokens": 1, "output_tokens": 2, "total_tokens": 3 }
+    }));
+
+    let output = transform_response_body(FormatTransform::ResponsesToChat, &input, None).expect("transform");
+    let value = json_from_bytes(output);
+
+    let message = &value["choices"][0]["message"];
+    assert_eq!(message["role"], json!("assistant"));
+    assert_eq!(message["content"], json!("Hello"));
+    assert_eq!(message["tool_calls"][0]["id"], json!("call_foo"));
+    assert_eq!(message["tool_calls"][0]["function"]["name"], json!("doThing"));
+    assert_eq!(message["tool_calls"][0]["function"]["arguments"], json!("{\"a\":1}"));
+    assert_eq!(message["content_parts"][0]["type"], json!("output_text"));
+    assert_eq!(message["content_parts"][1]["type"], json!("output_image"));
+    assert_eq!(value["choices"][0]["finish_reason"], json!("tool_calls"));
 }
 
 #[test]

--- a/src-tauri/src/proxy/response/responses_to_chat.rs
+++ b/src-tauri/src/proxy/response/responses_to_chat.rs
@@ -1,7 +1,10 @@
 use axum::body::Bytes;
 use futures_util::{stream::try_unfold, StreamExt};
-use serde_json::{json, Value};
-use std::{collections::VecDeque, sync::Arc};
+use serde_json::{json, Map, Value};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
 
 use super::super::log::{build_log_entry, LogContext, LogWriter};
 use super::super::sse::SseEventParser;
@@ -36,6 +39,19 @@ struct ResponsesToChatState<S> {
     sent_done: bool,
     logged: bool,
     upstream_ended: bool,
+    tool_calls: Vec<ToolCallState>,
+    tool_calls_by_item_id: HashMap<String, usize>,
+    // 非文本输出只透传一次，避免重复注入 content_parts。
+    content_parts_sent: bool,
+}
+
+struct ToolCallState {
+    index: usize,
+    call_id: String,
+    name: String,
+    arguments: String,
+    sent_initial: bool,
+    sent_arguments: bool,
 }
 
 impl<S> ResponsesToChatState<S>
@@ -67,6 +83,9 @@ where
             sent_done: false,
             logged: false,
             upstream_ended: false,
+            tool_calls: Vec::new(),
+            tool_calls_by_item_id: HashMap::new(),
+            content_parts_sent: false,
         }
     }
 
@@ -134,30 +153,290 @@ where
         let Some(event_type) = value.get("type").and_then(Value::as_str) else {
             return;
         };
-        if !event_type.ends_with("output_text.delta") {
+        if event_type.ends_with("output_text.delta") {
+            self.handle_output_text_delta(&value, token_texts);
             return;
         }
+        if event_type.ends_with("function_call_arguments.delta") {
+            self.handle_function_call_arguments_delta(&value);
+            return;
+        }
+        if event_type.ends_with("function_call_arguments.done") {
+            self.handle_function_call_arguments_done(&value);
+            return;
+        }
+        if event_type.ends_with("output_item.added") {
+            self.handle_output_item_added(&value);
+            return;
+        }
+        if event_type.ends_with("output_item.done") {
+            self.handle_output_item_done(&value);
+            return;
+        }
+        if event_type.ends_with("response.completed") {
+            self.handle_response_completed(&value);
+        }
+    }
+
+    fn handle_output_text_delta(&mut self, value: &Value, token_texts: &mut Vec<String>) {
         let Some(delta) = value.get("delta").and_then(Value::as_str) else {
             return;
         };
         token_texts.push(delta.to_string());
-
-        if !self.sent_role {
-            self.sent_role = true;
-            self.out.push_back(chat_chunk_sse(
-                &self.chat_id,
-                self.created,
-                &self.model,
-                json!({ "role": "assistant", "content": "" }),
-                None,
-            ));
-        }
-
+        self.ensure_role_sent();
         self.out.push_back(chat_chunk_sse(
             &self.chat_id,
             self.created,
             &self.model,
             json!({ "content": delta }),
+            None,
+        ));
+    }
+
+    fn handle_output_item_added(&mut self, value: &Value) {
+        let Some(item) = value.get("item").and_then(Value::as_object) else {
+            return;
+        };
+        let Some(item_type) = item.get("type").and_then(Value::as_str) else {
+            return;
+        };
+        if item_type == "function_call" {
+            self.handle_function_call_item_added(item);
+        }
+    }
+
+    fn handle_function_call_item_added(&mut self, item: &Map<String, Value>) {
+        let Some(item_id) = item.get("id").and_then(Value::as_str) else {
+            return;
+        };
+        let call_id = item.get("call_id").and_then(Value::as_str);
+        let name = item.get("name").and_then(Value::as_str);
+
+        let (index, call_id, name, should_emit) = {
+            let state = self.ensure_tool_call_state(item_id, call_id, name);
+            let should_emit = !state.sent_initial;
+            state.sent_initial = true;
+            (
+                state.index,
+                state.call_id.clone(),
+                state.name.clone(),
+                should_emit,
+            )
+        };
+        if should_emit {
+            let id = tool_call_id(&call_id, item_id);
+            self.push_tool_call_delta(index, &id, &name, "");
+        }
+    }
+
+    fn handle_function_call_arguments_delta(&mut self, value: &Value) {
+        let Some(item_id) = value.get("item_id").and_then(Value::as_str) else {
+            return;
+        };
+        let Some(delta) = value.get("delta").and_then(Value::as_str) else {
+            return;
+        };
+        let (index, call_id, name) = {
+            let state = self.ensure_tool_call_state(item_id, None, None);
+            state.arguments.push_str(delta);
+            state.sent_initial = true;
+            state.sent_arguments = true;
+            (state.index, state.call_id.clone(), state.name.clone())
+        };
+        let id = tool_call_id(&call_id, item_id);
+        self.push_tool_call_delta(index, &id, &name, delta);
+    }
+
+    fn handle_function_call_arguments_done(&mut self, value: &Value) {
+        let Some(item_id) = value.get("item_id").and_then(Value::as_str) else {
+            return;
+        };
+        let arguments = value.get("arguments").and_then(Value::as_str).unwrap_or("");
+        let name = value.get("name").and_then(Value::as_str);
+
+        let (index, call_id, name, should_emit) = {
+            let state = self.ensure_tool_call_state(item_id, None, name);
+            if !arguments.is_empty() {
+                state.arguments = arguments.to_string();
+            }
+            let should_emit = !arguments.is_empty() && !state.sent_arguments;
+            state.sent_initial = true;
+            if should_emit {
+                state.sent_arguments = true;
+            }
+            (state.index, state.call_id.clone(), state.name.clone(), should_emit)
+        };
+        if should_emit {
+            let id = tool_call_id(&call_id, item_id);
+            self.push_tool_call_delta(index, &id, &name, arguments);
+        }
+    }
+
+    fn handle_output_item_done(&mut self, value: &Value) {
+        let Some(item) = value.get("item").and_then(Value::as_object) else {
+            return;
+        };
+        let Some(item_type) = item.get("type").and_then(Value::as_str) else {
+            return;
+        };
+        match item_type {
+            "function_call" => self.handle_function_call_item_snapshot(item),
+            "message" => self.handle_message_item_snapshot(item),
+            _ => {}
+        }
+    }
+
+    fn handle_response_completed(&mut self, value: &Value) {
+        let Some(response) = value.get("response").and_then(Value::as_object) else {
+            return;
+        };
+        let Some(output) = response.get("output").and_then(Value::as_array) else {
+            return;
+        };
+        for item in output {
+            let Some(item) = item.as_object() else {
+                continue;
+            };
+            match item.get("type").and_then(Value::as_str) {
+                Some("function_call") => self.handle_function_call_item_snapshot(item),
+                Some("message") => self.handle_message_item_snapshot(item),
+                _ => {}
+            }
+        }
+    }
+
+    fn handle_function_call_item_snapshot(&mut self, item: &Map<String, Value>) {
+        let Some(item_id) = item.get("id").and_then(Value::as_str) else {
+            return;
+        };
+        let call_id = item.get("call_id").and_then(Value::as_str);
+        let name = item.get("name").and_then(Value::as_str);
+        let arguments = item.get("arguments").and_then(Value::as_str).unwrap_or("");
+
+        let (index, call_id, name, should_emit) = {
+            let state = self.ensure_tool_call_state(item_id, call_id, name);
+            if !arguments.is_empty() {
+                state.arguments = arguments.to_string();
+            }
+            let should_emit = !arguments.is_empty() && !state.sent_arguments;
+            state.sent_initial = true;
+            if should_emit {
+                state.sent_arguments = true;
+            }
+            (state.index, state.call_id.clone(), state.name.clone(), should_emit)
+        };
+        if should_emit {
+            let id = tool_call_id(&call_id, item_id);
+            self.push_tool_call_delta(index, &id, &name, arguments);
+        }
+    }
+
+    fn handle_message_item_snapshot(&mut self, item: &Map<String, Value>) {
+        if item.get("role").and_then(Value::as_str) != Some("assistant") {
+            return;
+        }
+        let Some(content) = item.get("content").and_then(Value::as_array) else {
+            return;
+        };
+        self.maybe_emit_content_parts(content);
+    }
+
+    fn ensure_tool_call_state(
+        &mut self,
+        item_id: &str,
+        call_id: Option<&str>,
+        name: Option<&str>,
+    ) -> &mut ToolCallState {
+        let index = if let Some(index) = self.tool_calls_by_item_id.get(item_id) {
+            *index
+        } else {
+            let index = self.tool_calls.len();
+            self.tool_calls_by_item_id
+                .insert(item_id.to_string(), index);
+            self.tool_calls.push(ToolCallState {
+                index,
+                call_id: String::new(),
+                name: String::new(),
+                arguments: String::new(),
+                sent_initial: false,
+                sent_arguments: false,
+            });
+            index
+        };
+
+        let state = self.tool_calls.get_mut(index).expect("tool call state");
+        if let Some(call_id) = call_id {
+            if state.call_id.is_empty() {
+                state.call_id = call_id.to_string();
+            }
+        }
+        if let Some(name) = name {
+            if state.name.is_empty() {
+                state.name = name.to_string();
+            }
+        }
+        state
+    }
+
+    fn maybe_emit_content_parts(&mut self, parts: &[Value]) {
+        if self.content_parts_sent {
+            return;
+        }
+        // Chat 标准没有 Responses 的非文本输出，这里用扩展字段保留原始内容。
+        let has_non_text = parts.iter().any(|part| {
+            part.get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|part_type| part_type != "output_text")
+        });
+        if !has_non_text {
+            return;
+        }
+        self.ensure_role_sent();
+        self.out.push_back(chat_chunk_sse(
+            &self.chat_id,
+            self.created,
+            &self.model,
+            json!({ "content_parts": parts }),
+            None,
+        ));
+        self.content_parts_sent = true;
+    }
+
+    fn ensure_role_sent(&mut self) {
+        if self.sent_role {
+            return;
+        }
+        self.sent_role = true;
+        self.out.push_back(chat_chunk_sse(
+            &self.chat_id,
+            self.created,
+            &self.model,
+            json!({ "role": "assistant", "content": "" }),
+            None,
+        ));
+    }
+
+    fn push_tool_call_delta(&mut self, index: usize, id: &str, name: &str, arguments: &str) {
+        self.ensure_role_sent();
+        let mut function = Map::new();
+        if !name.is_empty() {
+            function.insert("name".to_string(), Value::String(name.to_string()));
+        }
+        function.insert(
+            "arguments".to_string(),
+            Value::String(arguments.to_string()),
+        );
+        let tool_call = json!({
+            "index": index,
+            "id": id,
+            "type": "function",
+            "function": Value::Object(function)
+        });
+        self.out.push_back(chat_chunk_sse(
+            &self.chat_id,
+            self.created,
+            &self.model,
+            json!({ "tool_calls": [tool_call] }),
             None,
         ));
     }
@@ -172,7 +451,7 @@ where
             self.created,
             &self.model,
             json!({}),
-            Some("stop"),
+            Some(self.finish_reason()),
         ));
         self.out.push_back(Bytes::from("data: [DONE]\n\n"));
     }
@@ -184,6 +463,14 @@ where
         self.logged = true;
         let entry = build_log_entry(&self.context, self.collector.finish());
         self.log.clone().write_detached(entry);
+    }
+
+    fn finish_reason(&self) -> &'static str {
+        if self.tool_calls.is_empty() {
+            "stop"
+        } else {
+            "tool_calls"
+        }
     }
 }
 
@@ -208,4 +495,14 @@ fn chat_chunk_sse(
         ]
     });
     Bytes::from(format!("data: {}\n\n", chunk.to_string()))
+}
+
+fn tool_call_id(call_id: &str, item_id: &str) -> String {
+    if !call_id.is_empty() {
+        call_id.to_string()
+    } else if !item_id.is_empty() {
+        item_id.to_string()
+    } else {
+        "call_proxy".to_string()
+    }
 }

--- a/src-tauri/src/proxy/response/tests.rs
+++ b/src-tauri/src/proxy/response/tests.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use super::super::log::{LogContext, LogWriter};
+use tokio::time::{sleep, Instant as TokioInstant};
 
 fn run_async<T>(future: impl std::future::Future<Output = T>) -> T {
     tokio::runtime::Runtime::new()
@@ -36,26 +37,63 @@ fn parse_sse_json(bytes: &Bytes) -> Option<Value> {
     Some(serde_json::from_str::<Value>(data).expect("parse SSE JSON"))
 }
 
+async fn setup_responses_stream(prefix: &str) -> (Arc<LogWriter>, LogContext, PathBuf) {
+    let log_path = unique_log_path(prefix);
+    let log = Arc::new(
+        LogWriter::new(&log_path, None)
+            .await
+            .expect("create log writer"),
+    );
+    let context = LogContext {
+        path: "/v1/responses".to_string(),
+        provider: "openai-response".to_string(),
+        upstream_id: "unit-test".to_string(),
+        model: Some("unit-model".to_string()),
+        mapped_model: Some("unit-model".to_string()),
+        stream: true,
+        status: 200,
+        upstream_request_id: None,
+        start: Instant::now(),
+    };
+    (log, context, log_path)
+}
+
+async fn collect_responses_to_chat_chunks(
+    upstream: impl futures_util::stream::Stream<Item = Result<Bytes, reqwest::Error>>
+        + Unpin
+        + Send
+        + 'static,
+    context: LogContext,
+    log: Arc<LogWriter>,
+) -> Vec<Bytes> {
+    let token_tracker = super::super::token_rate::TokenRateTracker::new()
+        .register(None, None)
+        .await;
+    super::responses_to_chat::stream_responses_to_chat(upstream, context, log, token_tracker)
+        .map(|item| item.expect("stream item"))
+        .collect()
+        .await
+}
+
+async fn read_first_log_line(path: &PathBuf) -> String {
+    let deadline = TokioInstant::now() + std::time::Duration::from_secs(2);
+    loop {
+        if let Ok(contents) = tokio::fs::read_to_string(path).await {
+            if let Some(line) = contents.lines().next() {
+                return line.to_string();
+            }
+        }
+        if TokioInstant::now() >= deadline {
+            panic!("log line");
+        }
+        sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
 #[test]
 fn stream_responses_to_chat_emits_role_delta_and_done_and_logs_usage() {
     run_async(async {
-        let log_path = unique_log_path("responses_to_chat");
-        let log = Arc::new(
-            LogWriter::new(&log_path, None)
-                .await
-                .expect("create log writer"),
-        );
-        let context = LogContext {
-            path: "/v1/responses".to_string(),
-            provider: "openai-response".to_string(),
-            upstream_id: "unit-test".to_string(),
-            model: Some("unit-model".to_string()),
-            mapped_model: Some("unit-model".to_string()),
-            stream: true,
-            status: 200,
-            upstream_request_id: None,
-            start: Instant::now(),
-        };
+        let (log, context, log_path) = setup_responses_stream("responses_to_chat").await;
 
         let upstream = futures_util::stream::iter(vec![
             Ok(Bytes::from(
@@ -71,19 +109,7 @@ fn stream_responses_to_chat_emits_role_delta_and_done_and_logs_usage() {
             Ok(Bytes::from("data: [DONE]\n\n")),
         ]);
 
-        let token_tracker = super::super::token_rate::TokenRateTracker::new()
-            .register(None, None)
-            .await;
-        let chunks: Vec<Bytes> =
-            super::responses_to_chat::stream_responses_to_chat(
-                upstream,
-                context,
-                log.clone(),
-                token_tracker,
-            )
-            .map(|item| item.expect("stream item"))
-            .collect()
-            .await;
+        let chunks = collect_responses_to_chat_chunks(upstream, context, log.clone()).await;
 
         assert_eq!(chunks.len(), 5);
 
@@ -108,14 +134,104 @@ fn stream_responses_to_chat_emits_role_delta_and_done_and_logs_usage() {
 
         assert_eq!(String::from_utf8_lossy(&chunks[4]), "data: [DONE]\n\n");
 
-        let contents = tokio::fs::read_to_string(&log_path)
-            .await
-            .expect("read log");
-        let line = contents.lines().next().expect("log line");
-        let entry: Value = serde_json::from_str(line).expect("parse log entry");
+        let line = read_first_log_line(&log_path).await;
+        let entry: Value = serde_json::from_str(&line).expect("parse log entry");
         assert_eq!(entry["usage"]["input_tokens"], json!(1));
         assert_eq!(entry["usage"]["output_tokens"], json!(2));
         assert_eq!(entry["usage"]["total_tokens"], json!(3));
+    });
+}
+
+#[test]
+fn stream_responses_to_chat_emits_tool_call_deltas_and_finish_reason() {
+    run_async(async {
+        let (log, context, _log_path) =
+            setup_responses_stream("responses_to_chat_tool_calls").await;
+
+        let upstream = futures_util::stream::iter(vec![
+            Ok(Bytes::from(
+                "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"status\":\"in_progress\",\"call_id\":\"call_foo\",\"name\":\"getRandomNumber\",\"arguments\":\"\"}}\n\n",
+            )),
+            Ok(Bytes::from(
+                "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"output_index\":0,\"delta\":\"{\\\"a\\\":\\\"0\\\"\"}\n\n",
+            )),
+            Ok(Bytes::from(
+                "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"output_index\":0,\"delta\":\",\\\"b\\\":\\\"100\\\"}\"}\n\n",
+            )),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ]);
+
+        let chunks = collect_responses_to_chat_chunks(upstream, context, log.clone()).await;
+
+        assert_eq!(chunks.len(), 6);
+
+        let first = parse_sse_json(&chunks[0]).expect("json");
+        assert_eq!(first["choices"][0]["delta"]["role"], json!("assistant"));
+
+        let initial = parse_sse_json(&chunks[1]).expect("json");
+        assert_eq!(initial["choices"][0]["delta"]["tool_calls"][0]["id"], json!("call_foo"));
+        assert_eq!(
+            initial["choices"][0]["delta"]["tool_calls"][0]["function"]["name"],
+            json!("getRandomNumber")
+        );
+        assert_eq!(
+            initial["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"],
+            json!("")
+        );
+
+        let delta_1 = parse_sse_json(&chunks[2]).expect("json");
+        assert_eq!(
+            delta_1["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"],
+            json!("{\"a\":\"0\"")
+        );
+
+        let delta_2 = parse_sse_json(&chunks[3]).expect("json");
+        assert_eq!(
+            delta_2["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"],
+            json!(",\"b\":\"100\"}")
+        );
+
+        let done = parse_sse_json(&chunks[4]).expect("json");
+        assert_eq!(done["choices"][0]["finish_reason"], json!("tool_calls"));
+
+        assert_eq!(String::from_utf8_lossy(&chunks[5]), "data: [DONE]\n\n");
+    });
+}
+
+#[test]
+fn stream_responses_to_chat_emits_content_parts_for_non_text() {
+    run_async(async {
+        let (log, context, _log_path) =
+            setup_responses_stream("responses_to_chat_content_parts").await;
+
+        let upstream = futures_util::stream::iter(vec![
+            Ok(Bytes::from(
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}\n\n",
+            )),
+            Ok(Bytes::from(
+                "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"msg_1\",\"type\":\"message\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello\",\"annotations\":[]},{\"type\":\"output_image\",\"image_url\":{\"url\":\"https://example.com/a.png\"}}]}}\n\n",
+            )),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ]);
+
+        let chunks = collect_responses_to_chat_chunks(upstream, context, log.clone()).await;
+
+        assert_eq!(chunks.len(), 5);
+
+        let first = parse_sse_json(&chunks[0]).expect("json");
+        assert_eq!(first["choices"][0]["delta"]["role"], json!("assistant"));
+
+        let text_delta = parse_sse_json(&chunks[1]).expect("json");
+        assert_eq!(text_delta["choices"][0]["delta"]["content"], json!("Hello"));
+
+        let parts_delta = parse_sse_json(&chunks[2]).expect("json");
+        assert_eq!(parts_delta["choices"][0]["delta"]["content_parts"][0]["type"], json!("output_text"));
+        assert_eq!(parts_delta["choices"][0]["delta"]["content_parts"][1]["type"], json!("output_image"));
+
+        let done = parse_sse_json(&chunks[3]).expect("json");
+        assert_eq!(done["choices"][0]["finish_reason"], json!("stop"));
+
+        assert_eq!(String::from_utf8_lossy(&chunks[4]), "data: [DONE]\n\n");
     });
 }
 
@@ -226,11 +342,8 @@ fn stream_chat_to_responses_handles_chunk_boundaries_and_emits_created_delta_don
 
         assert_eq!(String::from_utf8_lossy(&chunks[9]), "data: [DONE]\n\n");
 
-        let contents = tokio::fs::read_to_string(&log_path)
-            .await
-            .expect("read log");
-        let line = contents.lines().next().expect("log line");
-        let entry: Value = serde_json::from_str(line).expect("parse log entry");
+        let line = read_first_log_line(&log_path).await;
+        let entry: Value = serde_json::from_str(&line).expect("parse log entry");
         assert_eq!(entry["usage"]["input_tokens"], json!(1));
         assert_eq!(entry["usage"]["output_tokens"], json!(2));
         assert_eq!(entry["usage"]["total_tokens"], json!(3));
@@ -340,11 +453,8 @@ fn stream_chat_to_responses_emits_function_call_events_and_includes_them_in_comp
 
         assert_eq!(String::from_utf8_lossy(&chunks[7]), "data: [DONE]\n\n");
 
-        let contents = tokio::fs::read_to_string(&log_path)
-            .await
-            .expect("read log");
-        let line = contents.lines().next().expect("log line");
-        let entry: Value = serde_json::from_str(line).expect("parse log entry");
+        let line = read_first_log_line(&log_path).await;
+        let entry: Value = serde_json::from_str(&line).expect("parse log entry");
         assert_eq!(entry["usage"]["input_tokens"], json!(1));
         assert_eq!(entry["usage"]["output_tokens"], json!(2));
         assert_eq!(entry["usage"]["total_tokens"], json!(3));

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -570,6 +570,7 @@ mod tests {
             port: 9208,
             local_api_key: None,
             log_path: PathBuf::from("proxy.log"),
+            max_request_body_bytes: 20 * 1024 * 1024,
             enable_api_format_conversion,
             upstream_strategy: UpstreamStrategy::PriorityRoundRobin,
             upstreams,


### PR DESCRIPTION
## What\n- Extend Responses→Chat streaming to emit tool call deltas and set finish_reason=tool_calls when tools are present.\n- Preserve non-text response parts by emitting a content_parts delta for assistant messages.\n- Enhance non-streamed Responses→Chat conversion to include tool_calls and content_parts.\n- Stabilize logging assertions in response streaming tests and add coverage for tool call/content parts behavior.\n- Update test config setup to include max_request_body_bytes to match ProxyConfig.\n\n## Why\nResponses→Chat previously only handled output_text.delta, which dropped tool_calls/function_call data and non-text output parts. This caused information loss for tool invocation flows and multimodal outputs. Tests also hit a race on async log writes and broke after adding max_request_body_bytes to ProxyConfig.\n\n## Implementation details\n- Track tool call state by item_id and emit tool_calls deltas from output_item.added and function_call_arguments.* events, with response.completed/output_item.done fallback.\n- Emit content_parts only when non-text parts exist to keep chat compatibility while preserving original parts.\n- Non-stream extraction combines output_text into content, attaches tool_calls, and sets finish_reason based on tool call presence.\n- Test helpers now wait for the first log line to appear before assertions.