### PR TITLE
Localize recent request timestamps to short date/medium time

### DIFF
--- a/src/features/dashboard/RecentRequestsTable.tsx
+++ b/src/features/dashboard/RecentRequestsTable.tsx
@@ -13,6 +13,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import type { DashboardRequestItem } from "@/features/dashboard/types";
 import { formatInteger } from "@/features/dashboard/format";
+import { useI18n } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 import { m } from "@/paraglide/messages.js";
 
@@ -21,10 +22,10 @@ const ROW_HEIGHT_PX = 44;
 const OVERSCAN = 6;
 
 const GRID_COLS = "grid-cols-[170px_1fr_1fr_90px_140px_90px]";
-const RECENT_REQUEST_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  dateStyle: "medium",
-  timeStyle: "short",
-});
+const RECENT_REQUEST_TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  dateStyle: "short",
+  timeStyle: "medium",
+};
 
 type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
 
@@ -41,18 +42,22 @@ function statusToVariant(status: number): BadgeVariant {
   return "outline";
 }
 
-function formatTimestamp(value: number) {
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "—" : RECENT_REQUEST_TIME_FORMATTER.format(date);
+function createRecentRequestTimeFormatter(locale: string) {
+  return new Intl.DateTimeFormat(locale, RECENT_REQUEST_TIME_FORMAT_OPTIONS);
 }
 
-function timeColumn(): ColumnDef<DashboardRequestItem> {
+function formatTimestamp(value: number, formatter: Intl.DateTimeFormat) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : formatter.format(date);
+}
+
+function timeColumn(formatter: Intl.DateTimeFormat): ColumnDef<DashboardRequestItem> {
   return {
     id: "time",
     header: m.dashboard_table_time(),
     cell: ({ row }) => (
       <span className="whitespace-nowrap text-xs text-muted-foreground">
-        {formatTimestamp(row.original.tsMs)}
+        {formatTimestamp(row.original.tsMs, formatter)}
       </span>
     ),
   };
@@ -114,8 +119,8 @@ function latencyColumn(): ColumnDef<DashboardRequestItem> {
   };
 }
 
-function buildColumns() {
-  return [timeColumn(), pathColumn(), providerColumn(), statusColumn(), tokensColumn(), latencyColumn()];
+function buildColumns(formatter: Intl.DateTimeFormat) {
+  return [timeColumn(formatter), pathColumn(), providerColumn(), statusColumn(), tokensColumn(), latencyColumn()];
 }
 
 function headerCellClass(columnId: string) {
@@ -233,7 +238,9 @@ function RecentRequestsBody({ rows, scrollKey }: { rows: Row<DashboardRequestIte
 }
 
 export function RecentRequestsTable({ items, scrollKey }: RecentRequestsTableProps) {
-  const columns = buildColumns();
+  const { locale } = useI18n();
+  const formatter = createRecentRequestTimeFormatter(locale);
+  const columns = buildColumns(formatter);
 
   const table = useReactTable({
     data: items,


### PR DESCRIPTION
## What
- Format recent request timestamps with short date + medium time.
- Build the formatter from the active i18n locale so the column follows language switches.

## Why
- Align the dashboard display with the requested time format and ensure locale-appropriate rendering.

## Details
- Replace the static formatter with per-locale Intl.DateTimeFormat options.
- Thread the formatter into the time column rendering to keep formatting consistent.

## Testing
- Not run (not requested).