### PR TITLE
Fix ARM Linux release builds by installing GTK dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Linux dependencies
-        if: steps.release_guard.outputs.skip != 'true' && matrix.platform == 'ubuntu-22.04'
+        if: steps.release_guard.outputs.skip != 'true' && (matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm')
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            libgtk-3-dev \
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
             librsvg2-dev \
@@ -186,10 +187,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            libgtk-3-dev \
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
             librsvg2-dev \


### PR DESCRIPTION
## Summary
- Run the Linux dependency install step on both ubuntu-22.04 and ubuntu-22.04-arm matrices for pre-release and release jobs.
- Add libgtk-3-dev alongside existing GTK/WebKit deps so gdk-3.0.pc is present when building gdk-sys for aarch64-unknown-linux-gnu.

## Why
ARM pre-release builds were failing because pkg-config could not find gdk-3.0 while compiling gdk-sys; the ARM runner never installed GTK development headers.

## Notes
- No tests run locally; CI should validate on the next workflow run.
