### PR TITLE
Fix ARM Linux prerelease by installing xdg-utils

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,14 +65,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Linux dependencies
-        if: steps.release_guard.outputs.skip != 'true' && matrix.platform == 'ubuntu-22.04'
+        if: steps.release_guard.outputs.skip != 'true' && (matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm')
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
             librsvg2-dev \
-            patchelf
+            patchelf \
+            xdg-utils
 
       - name: Install Rust toolchain
         if: steps.release_guard.outputs.skip != 'true'
@@ -186,14 +187,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
             librsvg2-dev \
-            patchelf
+            patchelf \
+            xdg-utils
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Install Linux dependencies for both ubuntu-22.04 and ubuntu-22.04-arm in prerelease and release jobs.
- Add xdg-utils so xdg-open is available during AppImage bundling.

## Context
- The aarch64 Tauri build failed while bundling the AppImage because /usr/bin/xdg-open (from xdg-utils) was missing on the runner.

## Implementation Details
- Broaden the Linux dependency step condition to cover arm runners as well as x86_64.
- Keep existing GTK/appindicator/librsvg/patchelf packages and append xdg-utils to satisfy xdg-open for Tauri’s AppImage tooling.

## Testing
- Not run locally; expect CI prerelease on ubuntu-22.04-arm to complete the AppImage/DEB/RPM artifacts.