### PR TITLE
Add release profile settings for smaller Tauri binaries

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,3 +38,9 @@ tiktoken-rs = "0.6.0"
 url = "2.5.8"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+
+[profile.release]
+codegen-units = 1
+strip = "symbols"
+panic = "abort"
+opt-level = "s"


### PR DESCRIPTION
## Summary
- Add a release profile in `src-tauri/Cargo.toml` with size-focused build settings.

## Why
- The goal is to reduce binary size and slightly improve startup time, using a balanced size/performance tradeoff (`opt-level = "s"`).

## Details
- `codegen-units = 1` to improve cross-module optimization.
- `strip = "symbols"` to remove debug symbols from release builds.
- `panic = "abort"` to avoid unwind overhead (confirm no dependency requires unwinding across FFI).
- `opt-level = "s"` for size-leaning optimization.
- LTO is intentionally omitted per follow-up request.