### PR TITLE
Fix build failure by removing unused upstream import

### DIFF
--- a/src/features/config/form.ts
+++ b/src/features/config/form.ts
@@ -6,7 +6,6 @@ import {
   type TrayTokenRateConfig,
   type UpstreamForm,
   TRAY_TOKEN_RATE_FORMATS,
-  UPSTREAM_STRATEGIES,
 } from "@/features/config/types";
 import { m } from "@/paraglide/messages.js";
 


### PR DESCRIPTION
## Summary
- Remove the unused `UPSTREAM_STRATEGIES` import from the config form.

## Why
- `pnpm build` failed with TS6133 (unused import) in `src/features/config/form.ts`.

## Details
- Pure cleanup; no runtime behavior changes.

## Testing
- Not run (typecheck previously failed at build step).
