### PR TITLE
Use minute-precision timestamps in Total Tokens chart

### DIFF
--- a/src/components/chart-area-interactive.tsx
+++ b/src/components/chart-area-interactive.tsx
@@ -16,7 +16,7 @@ import {
   type ChartConfig,
 } from "@/components/ui/chart"
 import {
-  createDashboardTimeFormatter,
+  createDashboardMinuteFormatter,
   formatDashboardTimestamp,
   formatInteger,
 } from "@/features/dashboard/format"
@@ -190,7 +190,7 @@ function ChartBody({ data, timeFormatter }: ChartBodyProps) {
 export function ChartAreaInteractive({ series }: ChartAreaInteractiveProps) {
   const { locale } = useI18n()
   const timeFormatter = React.useMemo(
-    () => createDashboardTimeFormatter(locale),
+    () => createDashboardMinuteFormatter(locale),
     [locale]
   )
   const chartData = React.useMemo(

--- a/src/features/dashboard/format.ts
+++ b/src/features/dashboard/format.ts
@@ -3,8 +3,17 @@ const DASHBOARD_TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   timeStyle: "medium",
 };
 
+const DASHBOARD_TIME_MINUTE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  dateStyle: "short",
+  timeStyle: "short",
+};
+
 export function createDashboardTimeFormatter(locale: string) {
   return new Intl.DateTimeFormat(locale, DASHBOARD_TIME_FORMAT_OPTIONS);
+}
+
+export function createDashboardMinuteFormatter(locale: string) {
+  return new Intl.DateTimeFormat(locale, DASHBOARD_TIME_MINUTE_FORMAT_OPTIONS);
 }
 
 export function formatDashboardTimestamp(tsMs: number, formatter: Intl.DateTimeFormat) {


### PR DESCRIPTION
## Summary
- Add a minute-precision dashboard time formatter.
- Switch the Total Tokens chart axis/tooltip to minute precision.

## Why
- The Total Tokens chart only needs minute-level granularity; seconds add noise.

## Implementation Notes
- Introduced `createDashboardMinuteFormatter` using `timeStyle: "short"` to omit seconds.
- Only `ChartAreaInteractive` uses the new formatter, keeping other dashboard timestamps unchanged.
