### PR TITLE
Hide empty-state label in Total Tokens chart

### DIFF
--- a/src/components/chart-area-interactive.tsx
+++ b/src/components/chart-area-interactive.tsx
@@ -179,9 +179,7 @@ function ChartBody({ data, timeFormatter }: ChartBodyProps) {
       {data.length ? (
         <ChartCanvas data={data} timeFormatter={timeFormatter} />
       ) : (
-        <div className="flex h-[250px] items-center justify-center text-sm text-muted-foreground">
-          {m.dashboard_no_data()}
-        </div>
+        <div className="h-[250px] rounded-md border border-dashed border-border/60 bg-muted/30" />
       )}
     </CardContent>
   )


### PR DESCRIPTION
## Summary
- remove the "No data" message from the Total Tokens chart when there is no series data
- keep layout by rendering a subtle dashed placeholder panel

## Why
- requested to avoid showing the empty-state label in the Total Tokens chart and keep the dashboard cleaner

## Implementation details
- replace the empty-state text block in `ChartAreaInteractive` with a dashed, muted placeholder container
- preserve the chart rendering path when data exists

## Testing
- not run (not requested)
