### PR TITLE
Show zero-line total tokens chart when data is empty

### DIFF
--- a/src/components/chart-area-interactive.tsx
+++ b/src/components/chart-area-interactive.tsx
@@ -20,7 +20,7 @@ import {
   formatDashboardTimestamp,
   formatInteger,
 } from "@/features/dashboard/format"
-import type { DashboardSeriesPoint } from "@/features/dashboard/types"
+import type { DashboardRange, DashboardSeriesPoint } from "@/features/dashboard/types"
 import { useI18n } from "@/lib/i18n"
 import { m } from "@/paraglide/messages.js"
 
@@ -43,12 +43,16 @@ const chartConfig = {
 
 type ChartAreaInteractiveProps = {
   series: DashboardSeriesPoint[]
+  range: DashboardRange
 }
 
 type ChartBodyProps = {
   data: ChartPoint[]
   timeFormatter: Intl.DateTimeFormat
 }
+
+const FALLBACK_RANGE_DAYS = 7
+const DAY_MS = 24 * 60 * 60 * 1000
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
@@ -93,6 +97,28 @@ function formatTick(value: unknown, formatter: Intl.DateTimeFormat) {
     return "—"
   }
   return formatDashboardTimestamp(tsMs, formatter)
+}
+
+function resolveRangeBounds(range: DashboardRange) {
+  const now = Date.now()
+  // range=all 时用最近 7 天生成 0 线的时间范围
+  const resolvedEnd = range.toTsMs ?? now
+  const resolvedStart =
+    range.fromTsMs ?? resolvedEnd - FALLBACK_RANGE_DAYS * DAY_MS
+  const start = Math.min(resolvedStart, resolvedEnd)
+  const end = Math.max(resolvedStart, resolvedEnd)
+  if (end <= start) {
+    return { start, end: start + 60 * 1000 }
+  }
+  return { start, end }
+}
+
+function buildZeroSeries(range: DashboardRange) {
+  const { start, end } = resolveRangeBounds(range)
+  return [
+    { tsMs: start, inputTokens: 0, outputTokens: 0 },
+    { tsMs: end, inputTokens: 0, outputTokens: 0 },
+  ]
 }
 
 function ChartHeader() {
@@ -176,29 +202,29 @@ function ChartCanvas({ data, timeFormatter }: ChartBodyProps) {
 function ChartBody({ data, timeFormatter }: ChartBodyProps) {
   return (
     <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
-      {data.length ? (
-        <ChartCanvas data={data} timeFormatter={timeFormatter} />
-      ) : (
-        <div className="h-[250px] rounded-md border border-dashed border-border/60 bg-muted/30" />
-      )}
+      <ChartCanvas data={data} timeFormatter={timeFormatter} />
     </CardContent>
   )
 }
 
-export function ChartAreaInteractive({ series }: ChartAreaInteractiveProps) {
+export function ChartAreaInteractive({ series, range }: ChartAreaInteractiveProps) {
   const { locale } = useI18n()
   const timeFormatter = React.useMemo(
     () => createDashboardMinuteFormatter(locale),
     [locale]
   )
   const chartData = React.useMemo(
-    () =>
-      series.map((item) => ({
+    () => {
+      if (!series.length) {
+        return buildZeroSeries(range)
+      }
+      return series.map((item) => ({
         tsMs: item.tsMs,
         inputTokens: item.inputTokens,
         outputTokens: item.outputTokens,
-      })),
-    [series]
+      }))
+    },
+    [range, series]
   )
 
   return (

--- a/src/features/dashboard/DashboardPanel.tsx
+++ b/src/features/dashboard/DashboardPanel.tsx
@@ -22,7 +22,7 @@ import {
   resolveDashboardRange,
   toDashboardTimeRange,
 } from "@/features/dashboard/range"
-import type { DashboardSnapshot } from "@/features/dashboard/types"
+import type { DashboardRange, DashboardSnapshot } from "@/features/dashboard/types"
 import { parseError } from "@/lib/error"
 import { cn } from "@/lib/utils"
 import { m } from "@/paraglide/messages.js"
@@ -59,6 +59,9 @@ function usePagination(totalRequests: number) {
 function useDashboardSnapshot() {
   const [rangePreset, setRangePreset] = useState<DashboardTimeRange>("today")
   const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null)
+  const [activeRange, setActiveRange] = useState<DashboardRange>(() =>
+    resolveDashboardRange("today")
+  )
   const [status, setStatus] = useState<DashboardStatus>("idle")
   const [statusMessage, setStatusMessage] = useState("")
   const totalRequests = snapshot?.summary.totalRequests ?? 0
@@ -70,6 +73,7 @@ function useDashboardSnapshot() {
     setStatusMessage("")
     try {
       const range = resolveDashboardRange(rangePreset)
+      setActiveRange(range)
       const offset = (page - 1) * RECENT_PAGE_SIZE
       const data = await readDashboardSnapshot(range, offset)
       setSnapshot(data)
@@ -93,6 +97,7 @@ function useDashboardSnapshot() {
     snapshot,
     status,
     statusMessage,
+    activeRange,
     rangePreset,
     pagination: { page, totalPages, totalRequests },
     refresh: loadSnapshot,
@@ -162,6 +167,7 @@ export function DashboardPanel() {
     snapshot,
     status,
     statusMessage,
+    activeRange,
     rangePreset,
     pagination,
     refresh,
@@ -196,6 +202,7 @@ export function DashboardPanel() {
       <div className="px-4 lg:px-6">
         <ChartAreaInteractive
           series={snapshot?.series ?? []}
+          range={activeRange}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Render the total tokens chart with a zero baseline when the series is empty
- Remove the empty-state placeholder so the chart always renders
- Pass the resolved dashboard range into the chart to bound the zero-line points

## Why
When there are no requests in the selected range, the total tokens panel should still show a meaningful 0 baseline instead of a blank state.

## Implementation details
- If the series is empty, build two zero points from the range start/end.
- For `range=all` (null bounds), fall back to the last 7 days.
- Normalize inverted/zero-length ranges by enforcing a minimum 1‑minute span.

## Testing
Not run (not requested).
