### PR TITLE
Guard dashboard snapshot updates against stale responses

### DIFF
--- a/src/features/dashboard/DashboardPanel.tsx
+++ b/src/features/dashboard/DashboardPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { AlertCircle, RefreshCcw } from "lucide-react"
 
 import { ChartAreaInteractive } from "@/components/chart-area-interactive"
@@ -67,18 +67,28 @@ function useDashboardSnapshot() {
   const totalRequests = snapshot?.summary.totalRequests ?? 0
   const { page, totalPages, resetPage, onPrevPage, onNextPage } =
     usePagination(totalRequests)
+  const requestSeq = useRef(0)
 
   const loadSnapshot = useCallback(async () => {
+    // Ignore out-of-order responses; only the latest request updates state.
+    const requestId = requestSeq.current + 1
+    requestSeq.current = requestId
     setStatus("loading")
     setStatusMessage("")
     try {
       const range = resolveDashboardRange(rangePreset)
-      setActiveRange(range)
       const offset = (page - 1) * RECENT_PAGE_SIZE
       const data = await readDashboardSnapshot(range, offset)
+      if (requestSeq.current !== requestId) {
+        return
+      }
       setSnapshot(data)
+      setActiveRange(range)
       setStatus("idle")
     } catch (error) {
+      if (requestSeq.current !== requestId) {
+        return
+      }
       setStatus("error")
       setStatusMessage(parseError(error))
     }


### PR DESCRIPTION
## Summary
- Add a request sequence guard to the dashboard snapshot loader.
- Update snapshot and active range together only for the latest request.

## Why
Concurrent dashboard fetches can resolve out of order, which can mismatch snapshot data and the active range and produce an incorrect zero-line range for empty series.

## Implementation details
- Introduce a `requestSeq` ref to tag each load.
- Ignore success/error responses that are not from the latest request before updating state.

## Testing
- Not run (not requested).
