### PR TITLE
ci: reuse Rust cache between prerelease and release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,10 @@ jobs:
         with:
           workspaces: "src-tauri"
           cache-on-failure: true
+          # Stable cache key for prerelease/release reuse; bump suffix to invalidate.
+          shared-key: "rust-${{ runner.os }}-${{ matrix.target }}-v1"
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
 
       - name: Compute prerelease version
         id: versioning
@@ -307,6 +311,10 @@ jobs:
         with:
           workspaces: "src-tauri"
           cache-on-failure: true
+          # Stable cache key for prerelease/release reuse; bump suffix to invalidate.
+          shared-key: "rust-${{ runner.os }}-${{ matrix.target }}-v1"
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
 
       - name: Build and release
         uses: tauri-apps/tauri-action@v0.6.0


### PR DESCRIPTION
## Summary
- Stabilize rust-cache keys so prerelease and release jobs can share the same cache.

## Why
- The release workflow bumps versions (including Cargo.lock), which changes rust-cache keys and forces cold builds. A stable key lets release reuse the prerelease cache and speeds up CI.

## Details
- Add a shared rust-cache key for both prerelease and release jobs.
- Disable job-id and rust-environment hash keys to avoid cache churn; bump the "-v1" suffix to invalidate when dependencies/toolchain change.