### PR TITLE
Make upstream editor dialog body scrollable

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -87,6 +87,16 @@ function AlertDialogDescription({
   )
 }
 
+function AlertDialogBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-body"
+      className={cn("max-h-[70vh] overflow-y-auto", className)}
+      {...props}
+    />
+  )
+}
+
 function AlertDialogAction({
   className,
   ...props
@@ -123,7 +133,7 @@ export {
   AlertDialogFooter,
   AlertDialogTitle,
   AlertDialogDescription,
+  AlertDialogBody,
   AlertDialogAction,
   AlertDialogCancel,
 }
-

--- a/src/features/config/cards/upstreams/editor-dialog.tsx
+++ b/src/features/config/cards/upstreams/editor-dialog.tsx
@@ -7,6 +7,7 @@ import {
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
+  AlertDialogBody,
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
@@ -465,15 +466,17 @@ export function UpstreamEditorDialog({
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
-        {editor.open ? (
-          <UpstreamEditorFields
-            draft={editor.draft}
-            providerOptions={providerOptions}
-            showApiKeys={showApiKeys}
-            onToggleApiKeys={onToggleApiKeys}
-            onChangeDraft={onChangeDraft}
-          />
-        ) : null}
+        <AlertDialogBody className="space-y-4 pr-1">
+          {editor.open ? (
+            <UpstreamEditorFields
+              draft={editor.draft}
+              providerOptions={providerOptions}
+              showApiKeys={showApiKeys}
+              onToggleApiKeys={onToggleApiKeys}
+              onChangeDraft={onChangeDraft}
+            />
+          ) : null}
+        </AlertDialogBody>
         <AlertDialogFooter>
           <AlertDialogCancel>{m.common_cancel()}</AlertDialogCancel>
           <AlertDialogAction onClick={onSave}>


### PR DESCRIPTION
## Summary
- add a reusable `AlertDialogBody` wrapper that caps height and enables vertical scrolling
- wrap the upstream add/edit form in the new body so the header and footer stay fixed while the form scrolls

## Why
- the upstream editor dialog content could exceed the viewport height and was not scrollable, making fields and actions inaccessible

## Implementation details
- `AlertDialogBody` applies `max-h-[70vh] overflow-y-auto` and exposes a `data-slot` for styling hooks
- the upstream editor dialog uses `AlertDialogBody` with spacing/padding to keep the scroll area clean

## Testing
- not run (not requested)
