### PR TITLE
docs: fix macOS command escaping in Chinese README

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 2. 若系统提示无法打开，执行：
 
 ```bash
-xattr -cr /Applications/Token\\ Proxy.app
+xattr -cr /Applications/Token\ Proxy.app
 ```
 
 ## 配置说明


### PR DESCRIPTION
## Summary
- Fix the escaping for the macOS quarantine command in README.zh-CN.md

## Why
- Double backslashes render incorrectly in shell; a single escaped space is the correct example

## Details
- Command now reads: 

## Testing
- Not run (docs only)