### PR TITLE
Increase prerelease guard interval to 90 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const THRESHOLD_MINUTES = 30;
+            const THRESHOLD_MINUTES = 90;
             const { owner, repo } = context.repo;
             const query = `
               query ($owner: String!, $repo: String!) {


### PR DESCRIPTION
## Summary
- Increase the prerelease freshness guard from 30 to 90 minutes in the release workflow.

## Why
- The requested cadence is 90 minutes to reduce duplicate prerelease tags/builds while still providing timely feedback after main merges.

## Implementation details
- Updated `THRESHOLD_MINUTES` in the prerelease tag guard step of `.github/workflows/release.yml`, which skips prerelease generation when the latest tag is newer than the threshold.
