### PR TITLE
ci: ensure pnpm store exists before caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Ensure pnpm store directory exists
+        run: node scripts/ensure-pnpm-store.mjs
+
       - name: Detect release bump commit
         id: release_guard
         run: node scripts/release-guard.mjs
@@ -287,6 +290,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+
+      - name: Ensure pnpm store directory exists
+        run: node scripts/ensure-pnpm-store.mjs
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Ensure pnpm store directory exists
+        run: node scripts/ensure-pnpm-store.mjs
+
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 

--- a/scripts/ensure-pnpm-store.mjs
+++ b/scripts/ensure-pnpm-store.mjs
@@ -1,0 +1,14 @@
+import { execFile } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { promisify } from "node:util";
+
+// Ensure pnpm store path exists so setup-node cache doesn't fail when install is skipped.
+const execFileAsync = promisify(execFile);
+const { stdout } = await execFileAsync("pnpm", ["store", "path", "--silent"]);
+const storePath = stdout.trim();
+
+if (!storePath) {
+  throw new Error("pnpm store path is empty.");
+}
+
+await mkdir(storePath, { recursive: true });


### PR DESCRIPTION
## What
- Add `scripts/ensure-pnpm-store.mjs` to create the pnpm store directory when missing.
- Invoke the script right after `setup-node` in the test and release workflows so the cache path always exists.

## Why
- The cache post-job step fails with “Path Validation Error … does not exist” when `pnpm install` is skipped by guards, leaving the store path absent.

## Details
- Resolve the store path via `pnpm store path --silent` and create it with `mkdir({ recursive: true })`.
- CI-only change; no runtime behavior changes.

## Tests
- Not run (CI config change only).
