### PR TITLE
Fix pnpm store path lookup on Windows CI

### DIFF
--- a/scripts/ensure-pnpm-store.mjs
+++ b/scripts/ensure-pnpm-store.mjs
@@ -4,7 +4,13 @@ import { promisify } from "node:util";
 
 // Ensure pnpm store path exists so setup-node cache doesn't fail when install is skipped.
 const execFileAsync = promisify(execFile);
-const { stdout } = await execFileAsync("pnpm", ["store", "path", "--silent"]);
+// Use corepack to avoid pnpm not being on PATH (e.g., Windows runners).
+const { stdout } = await execFileAsync("corepack", [
+  "pnpm",
+  "store",
+  "path",
+  "--silent",
+]);
 const storePath = stdout.trim();
 
 if (!storePath) {


### PR DESCRIPTION
## Summary\n- call pnpm via corepack in ensure-pnpm-store script to avoid PATH-related ENOENT on windows-latest\n- still resolve the pnpm store path and create the directory so setup-node cache can reuse it when installs are skipped\n\n## Context\n- pre-release workflow step "Ensure pnpm store directory exists" failed on windows-latest because the pnpm binary was not on PATH; Node 22 provides corepack by default, so invoking `corepack pnpm store path --silent` avoids the missing binary\n\n## Testing\n- not run (script-only change)