### PR TITLE
Show dev suffix in sidebar title

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -15,6 +15,7 @@ import { CONFIG_SECTIONS, DEFAULT_CONFIG_SECTION, getSectionRoute } from "@/feat
 
 export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
   const pathname = useRouterState({ select: (state) => state.location.pathname })
+  const appTitle = import.meta.env.DEV ? "Token Proxy (dev)" : "Token Proxy"
 
   return (
     <Sidebar collapsible="offcanvas" {...props}>
@@ -26,7 +27,7 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
               className="data-[slot=sidebar-menu-button]:!p-1.5"
             >
               <Link to={getSectionRoute(DEFAULT_CONFIG_SECTION)}>
-                <span className="text-base font-semibold">Token Proxy</span>
+                <span className="text-base font-semibold">{appTitle}</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>


### PR DESCRIPTION
## Summary
- show "Token Proxy (dev)" in the sidebar heading when running in development via `import.meta.env.DEV`
- keep the production sidebar title unchanged so it matches the main window branding

## Motivation
- align the in-app brand label with the existing dev window title to clearly signal environment and avoid confusion

## Implementation Notes
- compute `appTitle` once in `AppSidebar` based on `import.meta.env.DEV` and render it in the sidebar menu button

## Testing
- not run (UI-only change)