### PR TITLE
CI: Make stable releases PR-based (no direct pushes to main)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,59 +184,57 @@ jobs:
           prerelease: true
           generateReleaseNotes: true
 
-  test:
-    # 手动发布时复用测试流程，保持质量闸门
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/test.yml
-
-  prepare_release:
-    name: Prepare release
-    if: github.event_name == 'workflow_dispatch'
-    needs: test
+  stable_tag:
+    name: Tag release (main push)
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
     runs-on: ubuntu-22.04
     permissions:
       contents: write
     outputs:
-      version: ${{ steps.versioning.outputs.version }}
-      tag: ${{ steps.versioning.outputs.tag }}
+      version: ${{ steps.release_guard.outputs.version }}
+      tag: ${{ steps.create_tag.outputs.tag }}
       release_notes: ${{ steps.release_notes.outputs.release_body }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
+      - name: Release guard
+        id: release_guard
+        run: node scripts/release-guard.mjs
 
-      - name: Validate and bump version
-        id: versioning
-        run: node scripts/versioning.mjs release "${{ inputs.version }}"
+      - name: Abort if not a release commit
+        if: steps.release_guard.outputs.is_release != 'true'
+        run: |
+          echo "Not a release commit; skip tag." && exit 0
+        shell: bash
 
       - name: Resolve previous stable tag
         id: previous_tag
+        if: steps.release_guard.outputs.is_release == 'true'
         run: |
-          # Use the latest stable tag (vX.Y.Z) as release notes base.
-          tags=$(git tag --list 'v*' --sort=v:refname | grep -E '^v[0-9]+\\.[0-9]+\\.[0-9]+$' || true)
+          tags=$(git tag --list 'v*' --sort=v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
           prev=$(echo "$tags" | tail -n 1)
           echo "previous_tag=$prev" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and tag
+      - name: Create and push tag
+        id: create_tag
+        if: steps.release_guard.outputs.is_release == 'true'
         run: |
+          tag="v${{ steps.release_guard.outputs.version }}"
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json src-tauri/Cargo.lock
-          git commit -m "chore: release v${{ steps.versioning.outputs.version }}"
-          git tag -a "${{ steps.versioning.outputs.tag }}" -m "Release ${{ steps.versioning.outputs.version }}"
-          git push
-          git push --tags
+          git tag -a "$tag" -m "Release ${{ steps.release_guard.outputs.version }}"
+          git push origin "$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes
         id: release_notes
+        if: steps.release_guard.outputs.is_release == 'true'
         uses: actions/github-script@v7
         env:
-          RELEASE_TAG: ${{ steps.versioning.outputs.tag }}
+          RELEASE_TAG: ${{ steps.create_tag.outputs.tag }}
           PREVIOUS_TAG: ${{ steps.previous_tag.outputs.previous_tag }}
         with:
           script: |
@@ -253,10 +251,10 @@ jobs:
             const { data } = await github.rest.repos.generateReleaseNotes(params);
             core.setOutput("release_body", data.body ?? "");
 
-  release:
+  stable_release:
     name: Release (${{ matrix.platform }} / ${{ matrix.target }})
-    if: github.event_name == 'workflow_dispatch'
-    needs: prepare_release
+    needs: stable_tag
+    if: needs.stable_tag.outputs.tag != ''
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: write
@@ -277,7 +275,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare_release.outputs.tag }}
+          ref: ${{ needs.stable_tag.outputs.tag }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -333,8 +331,68 @@ jobs:
         with:
           tauriScript: "pnpm tauri"
           args: "--target ${{ matrix.target }}"
-          tagName: "${{ needs.prepare_release.outputs.tag }}"
-          releaseName: "Release ${{ needs.prepare_release.outputs.version }}"
-          releaseBody: ${{ needs.prepare_release.outputs.release_notes }}
+          tagName: "${{ needs.stable_tag.outputs.tag }}"
+          releaseName: "Release ${{ needs.stable_tag.outputs.version }}"
+          releaseBody: ${{ needs.stable_tag.outputs.release_notes }}
           prerelease: false
           generateReleaseNotes: false
+
+  prepare_release_pr:
+    name: Prepare release PR
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Validate and bump version
+        id: versioning
+        run: node scripts/versioning.mjs release "${{ inputs.version }}"
+
+      - name: Create release branch and commit
+        id: commit
+        run: |
+          version="${{ steps.versioning.outputs.version }}"
+          branch="release/v${version}"
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git switch -c "$branch"
+          git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json src-tauri/Cargo.lock
+          git commit -m "chore: release v${version}"
+          git push origin "HEAD:$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        uses: actions/github-script@v7
+        env:
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          VERSION: ${{ steps.versioning.outputs.version }}
+        with:
+          script: |
+            const branch = process.env.BRANCH;
+            const version = process.env.VERSION;
+            const title = `chore: release v${version}`;
+            const body = [
+              `## Release v${version}`,
+              "- 自动生成的发布 PR，合并后会自动打 tag 并发布正式版。",
+              "- 请确认 CI 通过后再合并。",
+            ].join("\n");
+            const { data } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: branch,
+              base: "main",
+              title,
+              body,
+              maintainer_can_modify: true,
+            });
+            core.setOutput("pr_url", data.html_url);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
     branches:
       - main

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -11,6 +11,26 @@ function setOutput(key, value) {
   }
 }
 
-const subject = execSync("git log -1 --pretty=%s", { encoding: "utf8" }).trim();
-const skip = subject.startsWith("chore: release v");
-setOutput("skip", skip);
+function readPackageVersion() {
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  return pkg.version;
+}
+
+function latestTag() {
+  const output = execSync("git tag --list 'v*' --sort=-v:refname | head -n 1", {
+    encoding: "utf8",
+  }).trim();
+  return output || "";
+}
+
+const version = readPackageVersion();
+const isPrerelease = version.includes("-");
+const currentTag = `v${version}`;
+const newestTag = latestTag();
+const isNewRelease = !isPrerelease && newestTag !== currentTag;
+
+setOutput("version", version);
+setOutput("latest_tag", newestTag);
+setOutput("is_release", isNewRelease ? "true" : "false");
+// For backward compatibility with prerelease job gating: skip prerelease when this is a new release commit.
+setOutput("skip", isNewRelease ? "true" : "false");


### PR DESCRIPTION
## Summary

This PR updates the release automation to comply with the repository rules that protect `main` (no direct pushes; changes must go through PRs). It fixes the GH013 CI failure caused by attempting to push to `refs/heads/main`.

## What changed

- **`.github/workflows/release.yml`**
  - `workflow_dispatch` no longer commits/tags on `main`. It now:
    - bumps versions via `scripts/versioning.mjs release <x.y.z>`
    - creates & pushes a `release/vx.y.z` branch
    - opens a PR back to `main`
  - Added **`stable_tag`** (triggered by `workflow_run` after `Test` succeeds on a `main` push) to:
    - detect release commits via `scripts/release-guard.mjs`
    - create & push an annotated `vX.Y.Z` tag
    - generate GitHub release notes
  - Added **`stable_release`** to build/publish the final GitHub Release from the tag.
  - Pre-release flow remains as-is, but it now skips when the merge commit is a stable release bump to avoid duplicate prereleases.

- **`.github/workflows/test.yml`**
  - Runs on `release/**` branch pushes so the release PR always has CI coverage.

- **`scripts/release-guard.mjs`**
  - Determines whether the current commit is a “new stable release” based on:
    - `package.json` version (must NOT contain a prerelease suffix like `-1`)
    - absence of the corresponding `v<version>` tag
  - Exposes `is_release` / `skip` / `version` outputs consumed by the workflows.

## Why

The repository ruleset blocks updates to `refs/heads/main` and requires changes via pull requests. The previous workflow attempted to commit and push directly to `main`, causing pushes to be rejected and CI to fail with GH013.

## How to cut a release now

1. Run the `Release` workflow manually and provide `x.y.z`.
2. Merge the auto-created release PR after CI passes.
3. After the merge, `Test` succeeds on `main` and the workflow will automatically tag `vX.Y.Z` and publish the stable release.

## Notes

- This assumes pushing tags is allowed by the repository rules (only `main` is protected). If tags are also restricted, we may need a ruleset adjustment (tag-only bypass) for the action.
