### PR TITLE
ci: make release PR branch creation idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,10 +365,11 @@ jobs:
           branch="release/v${version}"
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git switch -c "$branch"
+          git fetch origin "$branch" || true
+          git switch -C "$branch"
           git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json src-tauri/Cargo.lock
           git commit -m "chore: release v${version}"
-          git push origin "HEAD:$branch"
+          git push --force-with-lease=refs/heads/$branch origin "HEAD:$branch"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Create pull request


### PR DESCRIPTION
## Summary\n- fetch existing release branch, then recreate it to avoid stale history when rerunning the job\n- push with --force-with-lease so reruns can update the branch without non-fast-forward errors\n- keep the release PR creation step idempotent after manual retries\n\n## Context\nThe release workflow run for v0.1.2 failed because `git push origin HEAD:release/v0.1.2` was rejected as non-fast-forward when the branch already existed. This change makes the branch publishing step tolerant of existing branches, so manual or retried runs do not fail early.\n\n## Implementation details\n- fetch the existing release branch if it exists, then `git switch -C` to rebuild it from the current commit\n- push with `--force-with-lease=refs/heads/$branch` to update the remote only when the expected remote head matches\n\n## Testing\n- Not run (workflow-only change)