### PR TITLE
ci: move Ubuntu runners to latest images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   stable_tag:
     name: Tag release (main push)
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     outputs:
@@ -101,9 +101,9 @@ jobs:
             target: x86_64-apple-darwin
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
-          - platform: ubuntu-22.04
+          - platform: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - platform: ubuntu-22.04-arm
+          - platform: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
@@ -129,7 +129,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
+        if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'ubuntu-24.04-arm'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -173,7 +173,7 @@ jobs:
   prepare_release_pr:
     name: Prepare release PR
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   test:
     name: Test (Rust)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary\n- Switch the test workflow to use ubuntu-latest.\n- Update release jobs to run on ubuntu-latest for x86 and ubuntu-24.04-arm for ARM.\n- Align Linux dependency install conditions with the new runner labels.\n\n## Why\n- The task requires all Ubuntu-based CI to use the latest available runner images.\n\n## Details\n- .github/workflows/test.yml now runs on ubuntu-latest.\n- .github/workflows/release.yml uses ubuntu-latest for stable_tag and prepare_release_pr.\n- The release matrix now targets ubuntu-latest (x86_64) and ubuntu-24.04-arm (latest ARM tag), and the install step condition matches those labels.