### PR TITLE
fix(ui): align upstream enable/disable action icons

### DIFF
--- a/src/features/config/cards/upstreams/table.tsx
+++ b/src/features/config/cards/upstreams/table.tsx
@@ -167,9 +167,9 @@ function UpstreamRowActions({
           aria-label={enabled ? m.upstreams_row_disable({ rowLabel }) : m.upstreams_row_enable({ rowLabel })}
         >
           {enabled ? (
-            <Check className="size-4 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
-          ) : (
             <Ban className="size-4 text-muted-foreground" aria-hidden="true" />
+          ) : (
+            <Check className="size-4 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
           )}
         </Button>
         <Button


### PR DESCRIPTION
## What
Fix the Upstreams table row action icon so it reflects the **action** that will be performed (enable vs. disable), not the current status.

## Why
The toggle button’s label already described the action (e.g. “Disable …” when the upstream is enabled), but the icon was showing the opposite semantic (a “success” checkmark for enabled). This mismatch made the UI feel reversed/confusing.

## Changes
- Swap the `Check`/`Ban` icons in the Upstreams table row actions.
  - Enabled upstream → show `Ban` (action: disable)
  - Disabled upstream → show `Check` (action: enable)

## Implementation details
- UI-only change in `src/features/config/cards/upstreams/table.tsx` (`UpstreamRowActions`).
- No state/behavior changes; click handlers and `aria-label` semantics stay the same.
