### PR TITLE
Add restart-after-update action via Tauri process plugin

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -148,6 +148,7 @@
   "update_last_checked": "Last checked: {time}",
   "update_check": "Check for updates",
   "update_download_install": "Download & install",
+  "update_restart_now": "Restart now",
   "update_status_idle": "Not checked",
   "update_status_checking": "Checking",
   "update_status_available": "Update available",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -140,6 +140,7 @@
   "update_last_checked": "上次检查时间：{time}",
   "update_check": "检查更新",
   "update_download_install": "下载并安装",
+  "update_restart_now": "立即重启",
   "update_status_idle": "待检查",
   "update_status_checking": "检查中",
   "update_status_available": "可更新",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.18",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-process": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-updater": "^2",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.2
+      '@tauri-apps/plugin-process':
+        specifier: ^2
+        version: 2.3.1
       '@tauri-apps/plugin-updater':
         specifier: ^2
         version: 2.9.0
@@ -1388,6 +1391,9 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.2':
     resolution: {integrity: sha512-ei/yRRoCklWHImwpCcDK3VhNXx+QXM9793aQ64YxpqVF0BDuuIlXhZgiAkc15wnPVav+IbkYhmDJIv5R326Mew==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
 
   '@tauri-apps/plugin-updater@2.9.0':
     resolution: {integrity: sha512-j++sgY8XpeDvzImTrzWA08OqqGqgkNyxczLD7FjNJJx/uXxMZFz5nDcfkyoI/rCjYuj2101Tci/r/HFmOmoxCg==}
@@ -3315,6 +3321,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.9.6
 
   '@tauri-apps/plugin-opener@2.5.2':
+    dependencies:
+      '@tauri-apps/api': 2.9.1
+
+  '@tauri-apps/plugin-process@2.3.1':
     dependencies:
       '@tauri-apps/api': 2.9.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4853,6 +4853,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5142,6 +5152,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-updater",
  "tiktoken-rs",
  "tokio",
@@ -6731,4 +6742,3 @@ dependencies = [
  "syn 2.0.113",
  "winnow 0.7.14",
 ]
-

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
+tauri-plugin-process = "2"
 tauri-plugin-updater = "2"
 
 [profile.release]
@@ -47,4 +48,3 @@ codegen-units = 1
 strip = "symbols"
 panic = "abort"
 opt-level = "s"
-

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "process:default",
     "updater:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -235,6 +235,7 @@ pub fn run() {
         .setup(|app| {
             #[cfg(desktop)]
             {
+                app.handle().plugin(tauri_plugin_process::init())?;
                 app.handle()
                     .plugin(tauri_plugin_updater::Builder::new().build())?;
             }

--- a/src/features/config/cards/update-card.tsx
+++ b/src/features/config/cards/update-card.tsx
@@ -7,6 +7,7 @@ import {
   type SetStateAction,
 } from "react";
 import { getVersion } from "@tauri-apps/api/app";
+import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type DownloadEvent } from "@tauri-apps/plugin-updater";
 import { AlertCircle } from "lucide-react";
 
@@ -252,6 +253,18 @@ function useUpdateInstaller({ updateHandle, setState, markError }: UpdateInstall
   }, [markError, setState, updateHandle]);
 }
 
+function useAppRelauncher({ setState }: Pick<UpdateHelpers, "setState">) {
+  return useCallback(async () => {
+    setState((prev) => ({ ...prev, statusMessage: "" }));
+    try {
+      await relaunch();
+    } catch (error) {
+      // 安装成功但重启失败时，不应把更新状态标记为失败；仅展示错误提示。
+      setState((prev) => ({ ...prev, statusMessage: parseError(error) }));
+    }
+  }, [setState]);
+}
+
 function useUpdater() {
   const { state, setState, markError } = useUpdaterState();
   const checkForUpdate = useUpdateChecker({ setState, markError });
@@ -261,7 +274,9 @@ function useUpdater() {
     markError,
   });
 
-  return { state, actions: { checkForUpdate, downloadAndInstall } };
+  const relaunchApp = useAppRelauncher({ setState });
+
+  return { state, actions: { checkForUpdate, downloadAndInstall, relaunchApp } };
 }
 
 type UpdateStatusRowProps = {
@@ -355,11 +370,20 @@ function UpdateError({ message }: UpdateErrorProps) {
 type UpdateActionsProps = {
   canCheck: boolean;
   canInstall: boolean;
+  canRelaunch: boolean;
   onCheck: () => void;
   onInstall: () => void;
+  onRelaunch: () => void;
 };
 
-function UpdateActions({ canCheck, canInstall, onCheck, onInstall }: UpdateActionsProps) {
+function UpdateActions({
+  canCheck,
+  canInstall,
+  canRelaunch,
+  onCheck,
+  onInstall,
+  onRelaunch,
+}: UpdateActionsProps) {
   return (
     <div className="flex flex-wrap gap-2">
       <Button type="button" variant="outline" onClick={onCheck} disabled={!canCheck}>
@@ -368,6 +392,11 @@ function UpdateActions({ canCheck, canInstall, onCheck, onInstall }: UpdateActio
       <Button type="button" onClick={onInstall} disabled={!canInstall}>
         {m.update_download_install()}
       </Button>
+      {canRelaunch ? (
+        <Button type="button" variant="secondary" onClick={onRelaunch}>
+          {m.update_restart_now()}
+        </Button>
+      ) : null}
     </div>
   );
 }
@@ -398,6 +427,7 @@ export function UpdateCard() {
   const canCheck =
     state.status !== "checking" && state.status !== "downloading" && state.status !== "installing";
   const canInstall = state.status === "available" && !!state.updateHandle;
+  const canRelaunch = state.status === "installed";
 
   return (
     <Card data-slot="update-card">
@@ -420,8 +450,10 @@ export function UpdateCard() {
         <UpdateActions
           canCheck={canCheck}
           canInstall={canInstall}
+          canRelaunch={canRelaunch}
           onCheck={actions.checkForUpdate}
           onInstall={actions.downloadAndInstall}
+          onRelaunch={actions.relaunchApp}
         />
       </CardFooter>
     </Card>


### PR DESCRIPTION
## Summary\n- add Tauri process plugin on frontend/Rust and enable restart permission so the app can relaunch itself after updating\n- show a "Restart now" button when the updater reaches Installed and call `relaunch()`; surface relaunch errors without flipping the update state\n- add i18n strings for the new action\n\n## Why\nUsers were told to restart after installing an update but had no in-app control to do it; this adds a one-click restart flow.\n\n## Implementation details\n- Dependencies: add `@tauri-apps/plugin-process` and `tauri-plugin-process`, register the plugin on desktop, and allow process capability\n- UI: UpdateCard renders the new button only in "installed" state; keeps installer status and error message handling unchanged\n\n## Testing\n- pnpm run build\n- (cd src-tauri && cargo check)