### PR TITLE
Dashboard: plot input/output/cached/total token trends

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -202,6 +202,8 @@
   "dashboard_chart_title_usage_trend": "Usage Trend",
   "dashboard_chart_input_tokens": "Input",
   "dashboard_chart_output_tokens": "Output",
+  "dashboard_chart_cached_tokens": "Cached",
+  "dashboard_chart_total_tokens": "Total",
   "dashboard_stat_latency_ms": "Latency (ms)",
   "dashboard_hint_success_rate": "Success rate {rate}",
   "dashboard_hint_error_rate": "Error rate {rate}",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -191,6 +191,8 @@
   "dashboard_chart_title_usage_trend": "使用趋势",
   "dashboard_chart_input_tokens": "输入",
   "dashboard_chart_output_tokens": "输出",
+  "dashboard_chart_cached_tokens": "缓存",
+  "dashboard_chart_total_tokens": "总 Tokens",
   "dashboard_stat_latency_ms": "延迟 (ms)",
   "dashboard_hint_success_rate": "成功率 {rate}",
   "dashboard_hint_error_rate": "错误率 {rate}",

--- a/src-tauri/src/proxy/dashboard.rs
+++ b/src-tauri/src/proxy/dashboard.rs
@@ -45,6 +45,7 @@ pub(crate) struct DashboardSeriesPoint {
     pub(crate) input_tokens: u64,
     pub(crate) output_tokens: u64,
     pub(crate) cached_tokens: u64,
+    pub(crate) total_tokens: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -218,7 +219,12 @@ SELECT
   COALESCE(SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END), 0) AS error_requests,
   COALESCE(SUM(COALESCE(input_tokens, 0)), 0) AS input_tokens,
   COALESCE(SUM(COALESCE(output_tokens, 0)), 0) AS output_tokens,
-  COALESCE(SUM(COALESCE(cached_tokens, 0)), 0) AS cached_tokens
+  COALESCE(SUM(COALESCE(cached_tokens, 0)), 0) AS cached_tokens,
+  COALESCE(SUM(CASE
+    WHEN total_tokens IS NOT NULL THEN total_tokens
+    WHEN input_tokens IS NOT NULL OR output_tokens IS NOT NULL THEN COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)
+    ELSE 0
+  END), 0) AS total_tokens
 FROM request_logs
 WHERE (?1 IS NULL OR ts_ms >= ?1) AND (?2 IS NULL OR ts_ms <= ?2)
 GROUP BY bucket_ts_ms
@@ -239,6 +245,7 @@ ORDER BY bucket_ts_ms ASC;
         let input_tokens: i64 = row.try_get("input_tokens").ok()?;
         let output_tokens: i64 = row.try_get("output_tokens").ok()?;
         let cached_tokens: i64 = row.try_get("cached_tokens").ok()?;
+        let total_tokens: i64 = row.try_get("total_tokens").ok()?;
         Some(DashboardSeriesPoint {
             ts_ms: i64_to_u64(ts_ms),
             total_requests: i64_to_u64(total_requests),
@@ -246,6 +253,7 @@ ORDER BY bucket_ts_ms ASC;
             input_tokens: i64_to_u64(input_tokens),
             output_tokens: i64_to_u64(output_tokens),
             cached_tokens: i64_to_u64(cached_tokens),
+            total_tokens: i64_to_u64(total_tokens),
         })
     })
     .collect::<Vec<_>>();
@@ -309,6 +317,7 @@ fn fill_series_buckets(
                 input_tokens: 0,
                 output_tokens: 0,
                 cached_tokens: 0,
+                total_tokens: 0,
             });
         }
 
@@ -474,6 +483,7 @@ mod tests {
             input_tokens: total_requests,
             output_tokens: 0,
             cached_tokens: 0,
+            total_tokens: total_requests,
         }
     }
 

--- a/src/components/chart-area-interactive.tsx
+++ b/src/components/chart-area-interactive.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Area, AreaChart, CartesianGrid, XAxis } from "recharts"
+import { Area, CartesianGrid, ComposedChart, Line, XAxis } from "recharts"
 
 import {
   Card,
@@ -11,6 +11,8 @@ import {
 } from "@/components/ui/card"
 import {
   ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
   type ChartConfig,
@@ -28,6 +30,8 @@ type ChartPoint = {
   tsMs: number
   inputTokens: number
   outputTokens: number
+  cachedTokens: number
+  totalTokens: number
 }
 
 const chartConfig = {
@@ -38,6 +42,14 @@ const chartConfig = {
   outputTokens: {
     label: m.dashboard_chart_output_tokens(),
     color: "var(--chart-2)",
+  },
+  cachedTokens: {
+    label: m.dashboard_chart_cached_tokens(),
+    color: "var(--chart-3)",
+  },
+  totalTokens: {
+    label: m.dashboard_chart_total_tokens(),
+    color: "var(--chart-4)",
   },
 } satisfies ChartConfig
 
@@ -116,8 +128,8 @@ function resolveRangeBounds(range: DashboardRange) {
 function buildZeroSeries(range: DashboardRange) {
   const { start, end } = resolveRangeBounds(range)
   return [
-    { tsMs: start, inputTokens: 0, outputTokens: 0 },
-    { tsMs: end, inputTokens: 0, outputTokens: 0 },
+    { tsMs: start, inputTokens: 0, outputTokens: 0, cachedTokens: 0, totalTokens: 0 },
+    { tsMs: end, inputTokens: 0, outputTokens: 0, cachedTokens: 0, totalTokens: 0 },
   ]
 }
 
@@ -147,7 +159,7 @@ function ChartDefs() {
 function ChartCanvas({ data, timeFormatter }: ChartBodyProps) {
   return (
     <ChartContainer config={chartConfig} className="aspect-auto h-[250px] w-full">
-      <AreaChart data={data}>
+      <ComposedChart data={data}>
         <ChartDefs />
         <CartesianGrid vertical={false} />
         <XAxis
@@ -178,6 +190,7 @@ function ChartCanvas({ data, timeFormatter }: ChartBodyProps) {
             />
           }
         />
+        <ChartLegend content={<ChartLegendContent />} />
         <Area
           dataKey="inputTokens"
           type="monotone"
@@ -194,7 +207,22 @@ function ChartCanvas({ data, timeFormatter }: ChartBodyProps) {
           strokeWidth={2}
           dot={false}
         />
-      </AreaChart>
+        <Line
+          dataKey="cachedTokens"
+          type="monotone"
+          stroke="var(--color-cachedTokens)"
+          strokeDasharray="5 5"
+          strokeWidth={2}
+          dot={false}
+        />
+        <Line
+          dataKey="totalTokens"
+          type="monotone"
+          stroke="var(--color-totalTokens)"
+          strokeWidth={2}
+          dot={false}
+        />
+      </ComposedChart>
     </ChartContainer>
   )
 }
@@ -222,6 +250,8 @@ export function ChartAreaInteractive({ series, range }: ChartAreaInteractiveProp
         tsMs: item.tsMs,
         inputTokens: item.inputTokens,
         outputTokens: item.outputTokens,
+        cachedTokens: item.cachedTokens,
+        totalTokens: item.totalTokens,
       }))
     },
     [range, series]

--- a/src/features/dashboard/types.ts
+++ b/src/features/dashboard/types.ts
@@ -28,6 +28,7 @@ export type DashboardSeriesPoint = {
   inputTokens: number;
   outputTokens: number;
   cachedTokens: number;
+  totalTokens: number;
 };
 
 export type DashboardRequestItem = {


### PR DESCRIPTION
## What changed
- Backend: added `totalTokens` to the dashboard time-series buckets so the trend chart can plot a true total per interval.
- Frontend: updated the usage trend chart to display **four** token series:
  - Input (area)
  - Output (area)
  - Cached (dashed line)
  - Total (solid line)
  A legend was added so the series are always visible/identifiable.
- i18n/types: added chart labels for Cached/Total and extended the TS `DashboardSeriesPoint` type with `totalTokens`.

## Why
The task request was to show **input, output, cached, and total token** trend lines. Previously the chart only showed input/output, which made it hard to understand cache impact and reconcile the chart with the summary “Total Tokens” metric.

## Implementation details
- `totalTokens` is computed with the same fallback logic as the summary:
  - Prefer `request_logs.total_tokens` when available.
  - Otherwise fall back to `input_tokens + output_tokens`.
  - If neither exists, treat as `0`.
- The chart uses a `ComposedChart` to keep input/output as filled areas while rendering cached/total as lines for clarity (and to avoid stacking four fills).
