### PR TITLE
docs(readme): add complete config, routing, and auth docs (EN/zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,91 +2,100 @@
 
 English | [中文](README.zh-CN.md)
 
-A tool for proxying AI APIs, such as forwarding OpenAI API format, Gemini AI API format, Anthropic API format, running locally, used for counting total token usage, and also for load balancing, priority management, and similar functions.
+Local AI API gateway for OpenAI / Gemini / Anthropic. Runs on your machine, keeps tokens counted (SQLite), offers priority-based load balancing, optional OpenAI Chat↔Responses format conversion, and one-click setup for Claude Code / Codex.
 
-## macOS Installation
+> Default listen port: **9208** (release) / **19208** (debug builds).
 
-1. Download the app and move it to `/Applications`.
-2. If macOS blocks the app, run:
+---
 
+## What you get
+- Multiple providers: `openai`, `openai-response`, `anthropic`, `gemini`
+- Built-in routing + optional OpenAI Chat ⇄ Responses conversion
+- Per-upstream priority + two balancing strategies (fill-first / round-robin)
+- Model alias mapping (exact / prefix* / wildcard*) and response model rewrite
+- Local access key (Authorization) + upstream key injection
+- SQLite-powered dashboard (requests, tokens, cached tokens, latency, recent)
+- macOS tray live token rate (optional)
+
+## Quick start (macOS)
+1) Install: move `Token Proxy.app` to `/Applications`. If blocked: `xattr -cr /Applications/Token\ Proxy.app`.
+2) Launch the app. The proxy starts automatically.
+3) Open **Config File** tab, edit and save (writes `config.jsonc` in the Tauri config dir). Defaults are usable; just paste your upstream API keys.
+4) Call via curl (example with local auth):
 ```bash
-xattr -cr /Applications/Token\ Proxy.app
+curl -X POST \
+  -H "Authorization: Bearer YOUR_LOCAL_KEY" \
+  -H "Content-Type: application/json" \
+  http://127.0.0.1:9208/v1/chat/completions \
+  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"hi"}]}'
 ```
 
-## Configuration
+## Configuration reference
+- File: `config.jsonc` (comments + trailing commas allowed)
+- Location: Tauri **AppConfig** directory (resolved automatically by the app)
 
-- Config file: `config.jsonc` (JSONC with comments and trailing commas).
-- Location: Tauri config directory.
-- Saving rewrites the file; the leading comment block is preserved.
+### Core fields
+| Field | Default | Notes |
+| --- | --- | --- |
+| `host` | `127.0.0.1` | Listen address (IPv6 allowed; will be bracketed in URLs) |
+| `port` | `9208` release / `19208` debug | Change if the port is taken |
+| `local_api_key` | `null` | When set: incoming requests must send `Authorization: Bearer <key>`; the same header will **not** forward upstream. |
+| `app_proxy_url` | `null` | Proxy for app updater & as placeholder for upstreams (`"$app_proxy_url"`). Supports `http/https/socks5/socks5h`. |
+| `log_path` | `proxy.log` | Relative to config dir. **Release builds do not write this file** (only SQLite). |
+| `log_level` | `silent` | `silent|error|warn|info|debug|trace`; debug/trace log request headers (auth redacted) and small bodies (≤64KiB). |
+| `max_request_body_bytes` | `20971520` (20 MiB) | 0 = fallback to default. Protects inbound body size. |
+| `tray_token_rate.enabled` | `true` | macOS tray live rate; harmless elsewhere. |
+| `tray_token_rate.format` | `split` | `combined` (`total`), `split` (`↑in ↓out`), `both` (`total | ↑in ↓out`). |
+| `enable_api_format_conversion` | `false` | Allow OpenAI Chat↔Responses fallback with body/stream conversion. |
+| `upstream_strategy` | `priority_fill_first` | `priority_fill_first` (default) keeps trying the highest-priority group in list order; `priority_round_robin` rotates within each priority group. |
 
-Example:
+### Upstream entries (`upstreams[]`)
+| Field | Default | Notes |
+| --- | --- | --- |
+| `id` | required | Unique per upstream. |
+| `provider` | required | One of `openai`, `openai-response`, `anthropic`, `gemini`. |
+| `base_url` | required | Full base; overlapping path parts are de-duplicated. |
+| `api_key` | `null` | Provider-specific bearer/key; overrides request headers. |
+| `proxy_url` | `null` | Per-upstream proxy; supports `http/https/socks5/socks5h`; default is **no system proxy**. `$app_proxy_url` placeholder allowed. |
+| `priority` | `0` | Higher = tried earlier. Grouped by priority then by order (or round-robin). |
+| `enabled` | `true` | Disabled upstreams are skipped. |
+| `model_mappings` | `{}` | Exact / `prefix*` / `*`. Priority: exact > longest prefix > wildcard. Response echoes original alias. |
+| `overrides.header` | `{}` | Set/remove headers (null removes). Hop-by-hop/Host/Content-Length are always ignored. |
 
-```jsonc
-{
-  "host": "127.0.0.1",
-  "port": 9208,
-  "local_api_key": null,
-  "log_path": "proxy.log",
-  "log_level": "silent",
-  "enable_api_format_conversion": false,
-  "upstream_strategy": "priority_round_robin",
-  "upstreams": [
-    {
-      "id": "openai-default",
-      "provider": "openai",
-      "base_url": "https://api.openai.com",
-      "api_key": null,
-      "priority": 0,
-      "enabled": true,
-      "model_mappings": {
-        "gpt-4": "gpt-4.1",
-        "gpt-4*": "gpt-4.1-mini",
-        "*": "gpt-4.1-mini"
-      }
-    },
-    {
-      "id": "openai-responses",
-      "provider": "openai-response",
-      "base_url": "https://api.openai.com",
-      "api_key": null,
-      "priority": 0,
-      "enabled": true
-    },
-    {
-      "id": "anthropic-default",
-      "provider": "anthropic",
-      "base_url": "https://api.anthropic.com",
-      "api_key": null,
-      "priority": 0,
-      "enabled": true
-    },
-    {
-      "id": "gemini-default",
-      "provider": "gemini",
-      "base_url": "https://generativelanguage.googleapis.com",
-      "api_key": null,
-      "priority": 0,
-      "enabled": true
-    }
-  ]
-}
-```
+## Routing & format conversion
+- Gemini: `/v1beta/models/*:generateContent` and `*:streamGenerateContent` → `gemini` (SSE supported).
+- Anthropic: `/v1/messages` (and subpaths) and `/v1/complete` → `anthropic`.
+- OpenAI: `/v1/chat/completions` → `openai`; `/v1/responses` → `openai-response`.
+- Other paths: first provider with upstreams wins (prefers `openai`, then `openai-response`, then `anthropic`).
+- If the needed OpenAI provider is missing but `enable_api_format_conversion=true`, the proxy auto-converts request/response bodies and streams between Chat and Responses.
 
-Notes:
-- Request routing is built in: `/v1/chat/completions` → `openai`, `/v1/responses` → `openai-response`, `/v1/messages` (and subpaths) / `/v1/complete` → `anthropic`, `/v1beta/models/*:generateContent` / `*:streamGenerateContent` → `gemini`. OpenAI Chat/Responses conversion is controlled by `enable_api_format_conversion` (default: `false`). Anthropic/Gemini are pass-through (no format conversion).
-- Anthropic auth uses `x-api-key`. If `anthropic-version` is missing, the proxy injects `2023-06-01` (override by providing the header explicitly).
-- Gemini (Google AI Studio Gemini API) auth uses query parameter `key` (if missing and `api_key` is configured on the upstream, the proxy injects it). Streaming is SSE; token usage is extracted from `usageMetadata` when present.
-- `log_level` controls runtime tracing output (default: `silent`, meaning no logs). Allowed: `silent`, `error`, `warn`, `info`, `debug`, `trace`.
-  - When `log_level` is `debug`/`trace`, the proxy logs request headers (redacting auth headers) and small request bodies (up to 64KiB).
-- `priority` sorts descending; within the same priority group, upstreams follow the list order in the config file.
-- `enabled` disables an upstream without deleting it; disabled upstreams are ignored during load balancing.
-- `model_mappings` rewrites model names per upstream (exact match, prefix with `*`, wildcard `*`). Priority: exact > prefix > wildcard. Responses return the original model alias when a mapping applies.
+## Auth rules (important)
+- Local access: `local_api_key` enabled → require `Authorization: Bearer <key>`; this header will **not** be forwarded upstream.
+- Upstream auth resolution (per request):
+  - **OpenAI**: `upstream.api_key` → `x-openai-api-key` → `Authorization` (only if `local_api_key` is **not** set) → error.
+  - **Anthropic**: `upstream.api_key` → `x-api-key` / `x-anthropic-api-key` → error. Missing `anthropic-version` is auto-filled with `2023-06-01`.
+  - **Gemini**: `upstream.api_key` → `x-goog-api-key` → query `?key=...` → error.
 
-## Claude Code / Codex Integration
+## Load balancing & retries
+- Priorities: higher `priority` groups first; inside a group use list order (fill-first) or round-robin (if `priority_round_robin`).
+- Retryable conditions: network timeout/connect errors, or status 403/429/307/5xx **except** 504/524. Retries stay within the same priority group; then the next lower priority group is tried.
 
-The in-app **Config File** page provides one-click auto setup:
+## Observability
+- SQLite log: `data.db` in config dir. Stores per-request stats (tokens, cached tokens, latency, model, upstream).
+- `proxy.log`: only written in debug builds; release skips file logging.
+- Token rate: macOS tray shows live total or split rates (configurable via `tray_token_rate`).
+- Debug/trace log bodies capped at 64KiB.
 
-- Claude Code: writes `env` in `~/.claude/settings.json` (`ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`)
-- Codex: writes `[model_providers.openai]` in `~/.codex/config.toml` (`base_url`) and writes `OPENAI_API_KEY` in `~/.codex/auth.json`
+## Dashboard
+- In-app **Dashboard** page visualizes totals, per-provider stats, time series, and recent requests (page size 50, offset supported).
 
-A `.bak` backup file is created before overwriting. Restart the CLI for changes to take effect.
+## One-click CLI setup
+- Claude Code: writes `~/.claude/settings.json` `env` (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN` when local key is set).
+- Codex: writes `~/.codex/config.toml` `[model_providers.openai].base_url` → `http://127.0.0.1:<port>/v1`; writes `~/.codex/auth.json` `OPENAI_API_KEY`.
+- A `.bak` file is created before overwriting; restart the CLI to apply.
+
+## FAQ
+- **Port already in use?** Change `port` in `config.jsonc`; remember to update your client base URL.
+- **Got 401?** If `local_api_key` is set, you must send `Authorization: Bearer <key>`; upstream keys go to `x-openai-api-key` / `x-api-key` / `x-goog-api-key` / `?key=`.
+- **413 Payload Too Large?** Body exceeded `max_request_body_bytes` (default 20 MiB) or the 4 MiB transform limit for format-conversion requests.
+- **Why no system proxy?** By design, `reqwest` is built with `.no_proxy()`; set per-upstream `proxy_url` if needed.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,91 +2,100 @@
 
 [English](README.md) | 中文
 
-中转 ai api 的工具，比如转发 openai api 格式，gemini ai api 格式，Anthropic api 格式，在本地运行，用于统计总 token 用量的、也可以负载均衡、优先级之类的
+本地 AI API 网关，支持 OpenAI / Gemini / Anthropic。本地运行、记录 Token（SQLite），按优先级负载均衡，可选 OpenAI Chat↔Responses 互转，并提供 Claude Code / Codex 一键配置。
 
-## macOS 安装
+> 默认监听端口：**9208**（release）/ **19208**（debug 构建）。
 
-1. 下载应用并拖到 `/Applications`。
-2. 若系统提示无法打开，执行：
+---
 
+## 你能得到什么
+- 多提供商：`openai`、`openai-response`、`anthropic`、`gemini`
+- 内置路由，支持可选的 OpenAI Chat ⇄ Responses 自动转换
+- 上游优先级 + 两种策略（填满优先级组 / 轮询）
+- 模型别名映射（精确 / 前缀* / 通配*），响应会回写原始别名
+- 本地访问密钥（Authorization）+ 上游密钥自动注入
+- SQLite 仪表盘：请求数、Token、缓存 Token、延迟、最近请求
+- macOS 托盘实时 Token 速率（可选）
+
+## 快速上手（macOS）
+1) 安装：把 `Token Proxy.app` 放到 `/Applications`。若被拦截，执行 `xattr -cr /Applications/Token\ Proxy.app`。
+2) 启动应用，代理会自动运行。
+3) 打开 **Config File** 标签，编辑并保存（写入 Tauri 配置目录下的 `config.jsonc`）。默认配置可用，只需填入上游 API Key。
+4) 发请求（本地鉴权示例）：
 ```bash
-xattr -cr /Applications/Token\ Proxy.app
+curl -X POST \
+  -H "Authorization: Bearer 你的本地密钥" \
+  -H "Content-Type: application/json" \
+  http://127.0.0.1:9208/v1/chat/completions \
+  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"hi"}]}'
 ```
 
-## 配置说明
+## 配置参考
+- 文件：`config.jsonc`（支持注释与尾随逗号）
+- 位置：Tauri **AppConfig** 目录（应用自动解析）
 
-- 配置文件：`config.jsonc`（支持注释与尾随逗号）。
-- 位置：Tauri 配置目录。
-- 保存会重写文件；仅保留文件头部注释块。
+### 核心字段
+| 字段 | 默认值 | 说明 |
+| --- | --- | --- |
+| `host` | `127.0.0.1` | 监听地址；支持 IPv6（URL 会自动加方括号） |
+| `port` | `9208`（release）/`19208`（debug） | 端口冲突时修改 |
+| `local_api_key` | `null` | 设置后，入站必须带 `Authorization: Bearer <key>`；此头**不会**再转给上游 |
+| `app_proxy_url` | `null` | 应用更新 & 上游可复用的代理；支持 `http/https/socks5/socks5h`；可在 upstream `proxy_url` 用 `"$app_proxy_url"` 占位 |
+| `log_path` | `proxy.log` | 相对配置目录；**release 构建不写此文件**（仅写 SQLite） |
+| `log_level` | `silent` | `silent|error|warn|info|debug|trace`；debug/trace 会记录请求头（鉴权打码）与小体积请求体（≤64KiB） |
+| `max_request_body_bytes` | `20971520` (20 MiB) | 0 表示回落到默认；保护入站体积 |
+| `tray_token_rate.enabled` | `true` | macOS 托盘实时速率；其他平台无害 |
+| `tray_token_rate.format` | `split` | `combined`(总数) / `split`(↑入 ↓出) / `both`(总数 | ↑入 ↓出) |
+| `enable_api_format_conversion` | `false` | 允许 OpenAI Chat↔Responses 自动 fallback 与流式/体转换 |
+| `upstream_strategy` | `priority_fill_first` | `priority_fill_first` 默认先填满高优先级；`priority_round_robin` 在同组内轮询 |
 
-示例：
+### 上游条目（`upstreams[]`）
+| 字段 | 默认值 | 说明 |
+| --- | --- | --- |
+| `id` | 必填 | 唯一 |
+| `provider` | 必填 | `openai` / `openai-response` / `anthropic` / `gemini` |
+| `base_url` | 必填 | 完整基址，重复路径段会去重 |
+| `api_key` | `null` | 该 provider 的密钥；优先于请求头 |
+| `proxy_url` | `null` | 每个上游独立代理，支持 `http/https/socks5/socks5h`；默认**不走系统代理**；支持 `$app_proxy_url` |
+| `priority` | `0` | 越大越先尝试；同组按列表顺序或轮询 |
+| `enabled` | `true` | 可临时禁用上游 |
+| `model_mappings` | `{}` | 精确 / `前缀*` / `*`；优先级：精确 > 最长前缀 > 通配；响应回写原始模型别名 |
+| `overrides.header` | `{}` | 设置/删除 header（null 表示删除）；hop-by-hop/Host/Content-Length 永远忽略 |
 
-```jsonc
-{
-  "host": "127.0.0.1",
-  "port": 9208,
-  "local_api_key": null,
-  "log_path": "proxy.log",
-  "log_level": "silent",
-  "enable_api_format_conversion": false,
-  "upstream_strategy": "priority_round_robin",
-  "upstreams": [
-    {
-      "id": "openai-default",
-      "provider": "openai",
-      "base_url": "https://api.openai.com",
-      "api_key": null,
-      "priority": 0,
-      "enabled": true,
-      "model_mappings": {
-        "gpt-4": "gpt-4.1",
-        "gpt-4*": "gpt-4.1-mini",
-        "*": "gpt-4.1-mini"
-      }
-    },
-    {
-      "id": "openai-responses",
-      "provider": "openai-response",
-      "base_url": "https://api.openai.com",
-      "api_key": null,
-      "priority": 0,
-      "enabled": true
-    },
-    {
-      "id": "anthropic-default",
-      "provider": "anthropic",
-      "base_url": "https://api.anthropic.com",
-      "api_key": null,
-      "priority": 0,
-      "enabled": true
-    },
-    {
-      "id": "gemini-default",
-      "provider": "gemini",
-      "base_url": "https://generativelanguage.googleapis.com",
-      "api_key": null,
-      "priority": 0,
-      "enabled": true
-    }
-  ]
-}
-```
+## 路由与格式转换
+- Gemini：`/v1beta/models/*:generateContent`、`*:streamGenerateContent` → `gemini`（支持 SSE）
+- Anthropic：`/v1/messages`（含子路径）与 `/v1/complete` → `anthropic`
+- OpenAI：`/v1/chat/completions` → `openai`；`/v1/responses` → `openai-response`
+- 其他路径：按已配置的 provider 依次匹配（优先 `openai`，再 `openai-response`，再 `anthropic`）
+- 若缺少对应 OpenAI provider 且 `enable_api_format_conversion=true`，将自动在 Chat/Responses 之间转换请求与响应（含流式）
 
-说明：
-- 路由规则内置：`/v1/chat/completions` → `openai`，`/v1/responses` → `openai-response`，`/v1/messages`（及子路径）/`/v1/complete` → `anthropic`，`/v1beta/models/*:generateContent`/`*:streamGenerateContent` → `gemini`；OpenAI Chat/Responses 互转由 `enable_api_format_conversion` 控制（默认：`false`）。Anthropic/Gemini 不做格式转换。
-- Anthropic 鉴权使用 `x-api-key`；当请求未携带 `anthropic-version` 时，代理默认补 `2023-06-01`（可被请求头覆盖）。
-- Gemini（Google 官方 Gemini API）鉴权使用 query 参数 `key`（若请求未携带且 upstream 配置了 `api_key`，代理会自动补齐）；流式为 SSE，支持从 `usageMetadata` 统计 token。
-- `log_level` 控制运行时 tracing 日志输出（默认：`silent`，即不输出）。可选值：`silent`/`error`/`warn`/`info`/`debug`/`trace`。
-  - 当 `log_level` 为 `debug`/`trace` 时，代理会输出请求 header（鉴权相关会打码）和小体积请求体（最多 64KiB）。
-- `priority` 越大优先级越高；同优先级时按配置文件中的列表顺序。
-- `enabled` 用于禁用某个 upstream 而不删除；禁用的 upstream 不参与负载均衡。
-- `model_mappings` 用于按 upstream 重写模型名（精确匹配、前缀通配 `*`、全量通配 `*`）；优先级：精确 > 前缀 > 通配；当映射生效时，响应会回写原始模型别名。
+## 鉴权规则（重要）
+- 本地访问：设置了 `local_api_key` 必须带 `Authorization: Bearer <key>`；此头不会被转发给上游
+- 上游鉴权解析（逐请求）：
+  - **OpenAI**：`upstream.api_key` → `x-openai-api-key` → `Authorization`（仅当未设置 `local_api_key`）→ 报错
+  - **Anthropic**：`upstream.api_key` → `x-api-key` / `x-anthropic-api-key` → 报错；若缺少 `anthropic-version` 自动补 `2023-06-01`
+  - **Gemini**：`upstream.api_key` → `x-goog-api-key` → 查询参数 `?key=` → 报错
 
-## Claude Code / Codex 接入
+## 负载均衡与重试
+- 优先级：高优先级组先尝试；组内按列表顺序（fill-first）或轮询（round-robin）
+- 可重试条件：网络超时/连接错误，或状态码 403/429/307/5xx（排除 504/524）；先在当前优先级组内重试，再降级到下一优先级组
 
-应用内「配置文件」页面提供一键写入自动配置：
+## 可观测性
+- SQLite 日志：`data.db` 位于配置目录，记录每次请求（tokens、cached tokens、延迟、模型、上游）
+- `proxy.log`：仅 debug 构建写入；release 不写文件
+- Token 速率：macOS 托盘可显示总速率或分向（由 `tray_token_rate` 决定）
+- debug/trace 日志的请求体最大 64KiB
 
-- Claude Code：写入 `~/.claude/settings.json` 的 `env`（`ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`）
-- Codex：写入 `~/.codex/config.toml` 的 `[model_providers.openai]`（`base_url`），并写入 `~/.codex/auth.json`（`OPENAI_API_KEY`）
+## Dashboard
+- 应用内 **Dashboard** 展示总览、按 provider 统计、时间序列、最近请求（分页 50，支持 offset）
 
-写入前会生成 `.bak` 备份文件；修改后重启对应 CLI 生效。
+## 一键写 CLI 配置
+- Claude Code：写入 `~/.claude/settings.json` 的 `env`（`ANTHROPIC_BASE_URL`，若有本地密钥则写 `ANTHROPIC_AUTH_TOKEN`）
+- Codex：写入 `~/.codex/config.toml` 的 `[model_providers.openai].base_url` → `http://127.0.0.1:<port>/v1`；写入 `~/.codex/auth.json` 的 `OPENAI_API_KEY`
+- 写入前会生成 `.bak` 备份；写完重启对应 CLI 生效
+
+## FAQ
+- **端口被占用？** 修改 `config.jsonc` 里的 `port`，并同步更新客户端 base URL
+- **返回 401？** 设置了 `local_api_key` 就必须带 `Authorization: Bearer <key>`；上游密钥放 `x-openai-api-key` / `x-api-key` / `x-goog-api-key` / `?key=`
+- **413 Payload Too Large？** 请求体超过 `max_request_body_bytes`（默认 20 MiB）或格式转换场景的 4 MiB 处理上限
+- **为什么不走系统代理？** `reqwest` 默认 `no_proxy()`；如需代理，请在每个 upstream 设置 `proxy_url`


### PR DESCRIPTION
## Summary
This PR rewrites the English and Chinese READMEs to provide an accurate, user-focused reference for configuring and using Token Proxy.

## What changed
- Restructured the README into a quick start, feature overview, and configuration reference tables.
- Documented previously missing config fields and defaults (e.g. `app_proxy_url`, `max_request_body_bytes` (20 MiB), `tray_token_rate`, per-upstream `proxy_url` including `$app_proxy_url`, and header overrides).
- Clarified request routing and the optional OpenAI Chat ↔ Responses format conversion behavior.
- Clarified local vs upstream authentication precedence (including provider-specific headers and Gemini `?key=` support).
- Added sections for load balancing / retry semantics, observability (SQLite `data.db`, debug-only `proxy.log`), dashboard, and common troubleshooting.

## Why
The prior README was mainly an example plus a short notes section and did not fully describe the actual configuration schema and runtime behavior. This made it easy to misconfigure the app (especially around auth precedence, routing fallbacks, and body-size limits). The goal is to let normal users configure the app correctly without having to read the Rust source.

## Implementation notes
- The documentation is derived from the Rust implementation under `src-tauri/src/proxy/` so the defaults and behavior match what the app actually does.
- `max_request_body_bytes` defaults to 20 MiB (20971520 bytes) and numbers are shown as plain JSON-compatible integers.
- Release builds do not write `proxy.log` (SQLite is used for stats); debug/trace request body logging is capped.
- Retry behavior follows the current policy (403/429/307/5xx excluding 504/524) and retries stay within the same priority group before degrading.

## Testing
Not applicable (docs-only).
