### PR TITLE
i18n(zh): rename 智能体 to Agents

### DIFF
--- a/messages/zh.json
+++ b/messages/zh.json
@@ -35,7 +35,7 @@
   "config_section_strategy_desc": "全局上游选择规则",
   "config_section_upstreams_label": "上游",
   "config_section_upstreams_desc": "提供商池与 API Key",
-  "config_section_agents_label": "智能体",
+  "config_section_agents_label": "Agents",
   "config_section_agents_desc": "Claude Code / Codex 自动配置",
   "config_section_settings_label": "设置",
   "config_section_settings_desc": "配置文件、校验与更新",


### PR DESCRIPTION
## Summary
Align the Chinese UI with the canonical section name by labeling the Agents config section as **Agents**.

## What changed
- Updated `messages/zh.json`:
  - `config_section_agents_label`: `"智能体"` → `"Agents"`

## Why
The feature/section is referred to as **Agents** elsewhere (and already in the English locale). Keeping the Chinese menu label translated as “智能体” made navigation and cross-language references inconsistent. This change makes the sidebar wording consistent with the product name.

## Implementation notes
- This is a string-only i18n change; no runtime behavior is affected.
- The updated message will be picked up when Paraglide messages are compiled (e.g. via `pnpm run i18n:compile` / `pnpm run build`).

## Testing
N/A (translation change only).
