### PR TITLE
Codex auto-setup: token_proxy provider config + .token_proxy.bak backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ curl -X POST \
 
 ## One-click CLI setup
 - Claude Code: writes `~/.claude/settings.json` `env` (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN` when local key is set).
-- Codex: writes `~/.codex/config.toml` `[model_providers.openai].base_url` → `http://127.0.0.1:<port>/v1`; writes `~/.codex/auth.json` `OPENAI_API_KEY`.
-- A `.bak` file is created before overwriting; restart the CLI to apply.
+- Codex: writes `~/.codex/config.toml` `model_provider="token_proxy"` and `[model_providers.token_proxy].base_url` → `http://127.0.0.1:<port>/v1`; writes `~/.codex/auth.json` `OPENAI_API_KEY`.
+- A `.token_proxy.bak` file is created before overwriting; restart the CLI to apply.
 
 ## FAQ
 - **Port already in use?** Change `port` in `config.jsonc`; remember to update your client base URL.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,8 +91,8 @@ curl -X POST \
 
 ## 一键写 CLI 配置
 - Claude Code：写入 `~/.claude/settings.json` 的 `env`（`ANTHROPIC_BASE_URL`，若有本地密钥则写 `ANTHROPIC_AUTH_TOKEN`）
-- Codex：写入 `~/.codex/config.toml` 的 `[model_providers.openai].base_url` → `http://127.0.0.1:<port>/v1`；写入 `~/.codex/auth.json` 的 `OPENAI_API_KEY`
-- 写入前会生成 `.bak` 备份；写完重启对应 CLI 生效
+- Codex：写入 `~/.codex/config.toml` 的 `model_provider="token_proxy"` 与 `[model_providers.token_proxy].base_url` → `http://127.0.0.1:<port>/v1`；写入 `~/.codex/auth.json` 的 `OPENAI_API_KEY`
+- 写入前会生成 `.token_proxy.bak` 备份；写完重启对应 CLI 生效
 
 ## FAQ
 - **端口被占用？** 修改 `config.jsonc` 里的 `port`，并同步更新客户端 base URL

--- a/messages/en.json
+++ b/messages/en.json
@@ -161,7 +161,7 @@
   "client_setup_effective_env_label": "Effective env",
   "client_setup_effective_config_label": "Effective config",
   "client_setup_not_configured": "not configured",
-  "client_setup_backup_hint": "A .bak file is created before overwriting.",
+  "client_setup_backup_hint": "A .token_proxy.bak file is created before overwriting.",
   "client_setup_plaintext_warning": "Note: this writes tokens to disk in plain text. Keep your home directory secure.",
   "client_setup_apply": "Write",
   "client_setup_apply_success": "Wrote: {path}",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -153,7 +153,7 @@
   "client_setup_effective_env_label": "将写入的环境变量",
   "client_setup_effective_config_label": "将写入的配置片段",
   "client_setup_not_configured": "未配置",
-  "client_setup_backup_hint": "覆盖写入前会生成 .bak 备份文件。",
+  "client_setup_backup_hint": "覆盖写入前会生成 .token_proxy.bak 备份文件。",
   "client_setup_plaintext_warning": "注意：会将 token 以明文写入磁盘。请确保本机用户目录安全。",
   "client_setup_apply": "写入",
   "client_setup_apply_success": "已写入：{path}",

--- a/src-tauri/src/client_config.rs
+++ b/src-tauri/src/client_config.rs
@@ -8,6 +8,16 @@ use tauri::Manager;
 
 use crate::proxy::config::ProxyConfigFile;
 
+const CODEX_DISABLE_RESPONSE_STORAGE: bool = true;
+const CODEX_MODEL: &str = "gpt-5.2-codex";
+const CODEX_MODEL_PROVIDER: &str = "token_proxy";
+const CODEX_MODEL_REASONING_EFFORT: &str = "xhigh";
+const CODEX_NETWORK_ACCESS: &str = "enabled";
+const CODEX_PREFERRED_AUTH_METHOD: &str = "apikey";
+const CODEX_PROVIDER_NAME: &str = "token_proxy";
+const CODEX_PROVIDER_REQUIRES_OPENAI_AUTH: bool = true;
+const CODEX_PROVIDER_WIRE_API: &str = "responses";
+
 #[derive(Clone, Serialize)]
 pub(crate) struct ClientSetupInfo {
     pub(crate) proxy_http_base_url: String,
@@ -18,8 +28,18 @@ pub(crate) struct ClientSetupInfo {
 
     pub(crate) codex_config_path: String,
     pub(crate) codex_auth_path: String,
-    pub(crate) codex_openai_base_url: String,
-    pub(crate) codex_openai_api_key_configured: bool,
+
+    pub(crate) codex_disable_response_storage: bool,
+    pub(crate) codex_model: String,
+    pub(crate) codex_model_provider: String,
+    pub(crate) codex_model_reasoning_effort: String,
+    pub(crate) codex_network_access: String,
+    pub(crate) codex_preferred_auth_method: String,
+    pub(crate) codex_provider_base_url: String,
+    pub(crate) codex_provider_name: String,
+    pub(crate) codex_provider_requires_openai_auth: bool,
+    pub(crate) codex_provider_wire_api: String,
+    pub(crate) codex_api_key_configured: bool,
 }
 
 #[derive(Clone, Serialize)]
@@ -37,6 +57,7 @@ pub(crate) async fn preview(app: AppHandle) -> Result<ClientSetupInfo, String> {
         .local_api_key
         .as_ref()
         .is_some_and(|key| !key.trim().is_empty());
+    let codex_provider_base_url = build_codex_provider_base_url(&proxy_http_base_url);
 
     Ok(ClientSetupInfo {
         proxy_http_base_url: proxy_http_base_url.clone(),
@@ -45,8 +66,17 @@ pub(crate) async fn preview(app: AppHandle) -> Result<ClientSetupInfo, String> {
         claude_auth_token_configured: has_local_key,
         codex_config_path: codex_config_path.to_string_lossy().to_string(),
         codex_auth_path: codex_auth_path.to_string_lossy().to_string(),
-        codex_openai_base_url: format!("{proxy_http_base_url}/v1"),
-        codex_openai_api_key_configured: has_local_key,
+        codex_disable_response_storage: CODEX_DISABLE_RESPONSE_STORAGE,
+        codex_model: CODEX_MODEL.to_string(),
+        codex_model_provider: CODEX_MODEL_PROVIDER.to_string(),
+        codex_model_reasoning_effort: CODEX_MODEL_REASONING_EFFORT.to_string(),
+        codex_network_access: CODEX_NETWORK_ACCESS.to_string(),
+        codex_preferred_auth_method: CODEX_PREFERRED_AUTH_METHOD.to_string(),
+        codex_provider_base_url,
+        codex_provider_name: CODEX_PROVIDER_NAME.to_string(),
+        codex_provider_requires_openai_auth: CODEX_PROVIDER_REQUIRES_OPENAI_AUTH,
+        codex_provider_wire_api: CODEX_PROVIDER_WIRE_API.to_string(),
+        codex_api_key_configured: has_local_key,
     })
 }
 
@@ -90,23 +120,35 @@ pub(crate) async fn write_codex_config(app: AppHandle) -> Result<ClientConfigWri
     let proxy_http_base_url = build_proxy_http_base_url(&config)?;
     let config_path = resolve_codex_config_path(&app)?;
     let auth_path = resolve_codex_auth_path(&app)?;
+    let codex_provider_base_url = build_codex_provider_base_url(&proxy_http_base_url);
 
     // Codex 默认 config 路径为 $CODEX_HOME/config.toml，其中 CODEX_HOME 默认是 ~/.codex。
-    // 为了让 Codex 直接走本地代理，我们仅 patch model_providers.openai：
-    // - base_url = http://127.0.0.1:<port>/v1
+    // 为了让 Codex 直接走本地代理，我们写入固定的 token_proxy provider 配置，并尽量不动其他字段。
     //
-    // 鉴权不写 experimental_bearer_token，而是写 $CODEX_HOME/auth.json 的 OPENAI_API_KEY。
+    // - base_url = http://127.0.0.1:<port>/v1
+    // - preferred_auth_method = apikey
+    // - token 写入 $CODEX_HOME/auth.json 的 OPENAI_API_KEY（而非 experimental_bearer_token）
     let input = read_text_or_empty(&config_path).await?;
     let mut doc = toml_edit::DocumentMut::from_str(&input)
         .map_err(|err| format!("Failed to parse Codex config.toml: {err}"))?;
 
+    doc["disable_response_storage"] = toml_edit::value(CODEX_DISABLE_RESPONSE_STORAGE);
+    doc["model"] = toml_edit::value(CODEX_MODEL);
+    doc["model_provider"] = toml_edit::value(CODEX_MODEL_PROVIDER);
+    doc["model_reasoning_effort"] = toml_edit::value(CODEX_MODEL_REASONING_EFFORT);
+    doc["network_access"] = toml_edit::value(CODEX_NETWORK_ACCESS);
+    doc["preferred_auth_method"] = toml_edit::value(CODEX_PREFERRED_AUTH_METHOD);
+
     ensure_toml_table_path(&mut doc, &["model_providers"])?;
-    ensure_toml_table_path(&mut doc, &["model_providers", "openai"])?;
+    ensure_toml_table_path(&mut doc, &["model_providers", CODEX_MODEL_PROVIDER])?;
 
-    doc["model_providers"]["openai"]["base_url"] =
-        toml_edit::value(format!("{proxy_http_base_url}/v1"));
+    doc["model_providers"][CODEX_MODEL_PROVIDER]["base_url"] = toml_edit::value(codex_provider_base_url);
+    doc["model_providers"][CODEX_MODEL_PROVIDER]["name"] = toml_edit::value(CODEX_PROVIDER_NAME);
+    doc["model_providers"][CODEX_MODEL_PROVIDER]["requires_openai_auth"] =
+        toml_edit::value(CODEX_PROVIDER_REQUIRES_OPENAI_AUTH);
+    doc["model_providers"][CODEX_MODEL_PROVIDER]["wire_api"] = toml_edit::value(CODEX_PROVIDER_WIRE_API);
 
-    if let Some(table) = doc["model_providers"]["openai"].as_table_mut() {
+    if let Some(table) = doc["model_providers"][CODEX_MODEL_PROVIDER].as_table_mut() {
         table.remove("experimental_bearer_token");
     }
 
@@ -194,6 +236,10 @@ fn build_proxy_http_base_url(config: &ProxyConfigFile) -> Result<String, String>
     Ok(format!("http://{url_host}:{}", config.port))
 }
 
+fn build_codex_provider_base_url(proxy_http_base_url: &str) -> String {
+    format!("{proxy_http_base_url}/v1")
+}
+
 async fn read_text_or_empty(path: &Path) -> Result<String, String> {
     match tokio::fs::read_to_string(path).await {
         Ok(contents) => Ok(contents),
@@ -239,7 +285,7 @@ async fn write_json_with_backup(path: &Path, value: &serde_json::Value) -> Resul
         .map_err(|err| format!("Failed to create {}: {err}", parent.display()))?;
 
     if tokio::fs::try_exists(path).await.unwrap_or(false) {
-        let backup_path = path.with_extension("json.bak");
+        let backup_path = build_backup_path(path);
         let contents = tokio::fs::read_to_string(path)
             .await
             .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
@@ -264,7 +310,7 @@ async fn write_text_with_backup(path: &Path, contents: String) -> Result<(), Str
         .map_err(|err| format!("Failed to create {}: {err}", parent.display()))?;
 
     if tokio::fs::try_exists(path).await.unwrap_or(false) {
-        let backup_path = path.with_extension("toml.bak");
+        let backup_path = build_backup_path(path);
         let old = tokio::fs::read_to_string(path)
             .await
             .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
@@ -282,6 +328,17 @@ async fn write_text_with_backup(path: &Path, contents: String) -> Result<(), Str
         .await
         .map_err(|err| format!("Failed to write {}: {err}", path.display()))?;
     Ok(())
+}
+
+fn build_backup_path(path: &Path) -> PathBuf {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .filter(|ext| !ext.is_empty())
+    {
+        Some(extension) => path.with_extension(format!("{extension}.token_proxy.bak")),
+        None => path.with_extension("token_proxy.bak"),
+    }
 }
 
 fn ensure_toml_table_path(

--- a/src/features/config/cards/client-setup-card.tsx
+++ b/src/features/config/cards/client-setup-card.tsx
@@ -14,9 +14,18 @@ type ClientSetupInfo = {
   claude_base_url: string;
   claude_auth_token_configured: boolean;
   codex_config_path: string;
-  codex_openai_base_url: string;
   codex_auth_path: string;
-  codex_openai_api_key_configured: boolean;
+  codex_disable_response_storage: boolean;
+  codex_model: string;
+  codex_model_provider: string;
+  codex_model_reasoning_effort: string;
+  codex_network_access: string;
+  codex_preferred_auth_method: string;
+  codex_provider_base_url: string;
+  codex_provider_name: string;
+  codex_provider_requires_openai_auth: boolean;
+  codex_provider_wire_api: string;
+  codex_api_key_configured: boolean;
 };
 
 type ClientConfigWriteResult = {
@@ -232,11 +241,22 @@ export function ClientSetupCard({ savedAt, isDirty }: ClientSetupCardProps) {
                   {m.client_setup_effective_config_label()}
                 </p>
                 <div className="space-y-1 font-mono text-xs text-foreground/80">
-                  <div>[model_providers.openai]</div>
-                  <div>base_url = "{setup.codex_openai_base_url}"</div>
+                  <div>disable_response_storage = {setup.codex_disable_response_storage ? "true" : "false"}</div>
+                  <div>model = "{setup.codex_model}"</div>
+                  <div>model_provider = "{setup.codex_model_provider}"</div>
+                  <div>model_reasoning_effort = "{setup.codex_model_reasoning_effort}"</div>
+                  <div>network_access = "{setup.codex_network_access}"</div>
+                  <div>preferred_auth_method = "{setup.codex_preferred_auth_method}"</div>
+                  <div>[model_providers.{setup.codex_model_provider}]</div>
+                  <div>base_url = "{setup.codex_provider_base_url}"</div>
+                  <div>name = "{setup.codex_provider_name}"</div>
+                  <div>
+                    requires_openai_auth = {setup.codex_provider_requires_openai_auth ? "true" : "false"}
+                  </div>
+                  <div>wire_api = "{setup.codex_provider_wire_api}"</div>
                   <div>
                     {`auth.json: OPENAI_API_KEY = "${
-                      setup.codex_openai_api_key_configured
+                      setup.codex_api_key_configured
                         ? "••••••••"
                         : m.client_setup_not_configured()
                     }"`}


### PR DESCRIPTION
## What
Updates the in-app Codex auto-setup writer to generate a full Codex `config.toml` snippet using a dedicated `token_proxy` model provider, and switches overwrite backups to `*.token_proxy.bak`.

## Why
The previous setup only patched `[model_providers.openai].base_url`, which doesn’t match the desired Codex config format when using Token Proxy as a first-class provider. This PR aligns the generated settings with the requested format and makes backups clearly attributable.

## Changes
- `write_codex_config` now writes/overwrites:
  - Top-level Codex keys:
    - `disable_response_storage = true`
    - `model = "gpt-5.2-codex"`
    - `model_provider = "token_proxy"`
    - `model_reasoning_effort = "xhigh"`
    - `network_access = "enabled"`
    - `preferred_auth_method = "apikey"`
  - Provider block:
    - `[model_providers.token_proxy]`
    - `base_url = "http://127.0.0.1:<port>/v1"` (concrete proxy URL)
    - `name = "token_proxy"`
    - `requires_openai_auth = true`
    - `wire_api = "responses"`
- Auth remains written to `~/.codex/auth.json` (`OPENAI_API_KEY`), and any `experimental_bearer_token` field is removed to avoid mixed auth paths.
- Backup files created before overwriting are renamed from `*.json.bak`/`*.toml.bak` to `*.token_proxy.bak` (e.g. `config.toml.token_proxy.bak`, `auth.json.token_proxy.bak`, `settings.json.token_proxy.bak`).
- UI preview and docs are updated to reflect the new config snippet and backup suffix.

## Implementation notes
- Uses `toml_edit` to preserve unrelated `config.toml` content/formatting while patching only the keys above.
- Preview data returned by `preview_client_setup` now includes the exact effective values used by the writer so the UI stays in sync.

## Testing
- `cd src-tauri && cargo test`
- `pnpm run i18n:compile && pnpm tsc --noEmit`
