### PR TITLE
Redesign Agents setup list with modal details

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,124 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = ({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>) => (
+  <DialogPrimitive.Overlay
+    data-slot="dialog-overlay"
+    className={cn(
+      "bg-background/80 fixed inset-0 z-50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+)
+
+const DialogContent = ({
+  className,
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      data-slot="dialog-content"
+      className={cn(
+        "bg-background fixed left-[50%] top-[50%] z-50 grid w-full max-w-xl translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close
+        data-slot="dialog-close"
+        className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
+      >
+        <XIcon className="size-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+)
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-body"
+      className={cn("max-h-[70vh] overflow-y-auto", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogPortal,
+  DialogClose,
+  DialogOverlay,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogBody,
+}

--- a/src/features/config/cards/client-setup-card.tsx
+++ b/src/features/config/cards/client-setup-card.tsx
@@ -1,9 +1,20 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { invoke } from "@tauri-apps/api/core";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { parseError } from "@/lib/error";
 import { m } from "@/paraglide/messages.js";
@@ -69,20 +80,267 @@ type ClientSetupCardProps = {
   isDirty: boolean;
 };
 
-export function ClientSetupCard({ savedAt, isDirty }: ClientSetupCardProps) {
+type ToolSetupDialogProps = {
+  title: string;
+  description: string;
+  summary: ReactNode;
+  action: ActionState;
+  canApply: boolean;
+  isWorking: boolean;
+  onApply: () => void;
+  children: ReactNode;
+};
+
+function SummaryItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+      <span className="shrink-0 uppercase tracking-[0.2em]">{label}</span>
+      <span className="min-w-0 truncate font-mono text-foreground/80">{value}</span>
+    </div>
+  );
+}
+
+function DetailSection({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+function MonoBlock({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-md border border-border/60 bg-background/60 p-3">
+      {children}
+    </div>
+  );
+}
+
+function PathList({ paths }: { paths: readonly string[] }) {
+  return (
+    <MonoBlock>
+      <div className="space-y-1 font-mono text-xs text-foreground/80 break-all">
+        {paths.map((path, index) => (
+          <div key={index}>{path}</div>
+        ))}
+      </div>
+    </MonoBlock>
+  );
+}
+
+function CodeBlock({ lines }: { lines: readonly string[] }) {
+  return (
+    <MonoBlock>
+      <div className="overflow-x-auto">
+        <div className="min-w-max space-y-1 font-mono text-xs text-foreground/80 whitespace-pre">
+          {lines.map((line, index) => (
+            <div key={index}>{line}</div>
+          ))}
+        </div>
+      </div>
+    </MonoBlock>
+  );
+}
+
+type ToolSetupRowProps = Pick<ToolSetupDialogProps, "title" | "description" | "summary" | "action">;
+
+function ToolSetupRow({ title, description, summary, action }: ToolSetupRowProps) {
+  return (
+    <div className="rounded-md border border-border/60 bg-background/60 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 space-y-2">
+          <div className="space-y-0.5">
+            <p className="truncate text-sm font-medium text-foreground">{title}</p>
+            <p className="text-xs text-muted-foreground">{description}</p>
+          </div>
+          {summary}
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={toBadgeVariant(action.state)}>{toBadgeLabel(action.state)}</Badge>
+          <DialogTrigger asChild>
+            <Button type="button" variant="outline" size="sm">
+              {m.common_show()}
+            </Button>
+          </DialogTrigger>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type ToolSetupModalProps = Omit<ToolSetupDialogProps, "summary">;
+
+function ToolSetupModal({
+  title,
+  description,
+  action,
+  canApply,
+  isWorking,
+  onApply,
+  children,
+}: ToolSetupModalProps) {
+  return (
+    <DialogContent className="max-w-2xl">
+      <DialogHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </div>
+          <Badge variant={toBadgeVariant(action.state)}>{toBadgeLabel(action.state)}</Badge>
+        </div>
+      </DialogHeader>
+
+      <DialogBody className="space-y-4">
+        {children}
+
+        {action.message ? (
+          <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+            {action.message}
+          </div>
+        ) : null}
+
+        <p className="text-xs text-muted-foreground">{m.client_setup_backup_hint()}</p>
+      </DialogBody>
+
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button type="button" variant="outline">
+            {m.common_close()}
+          </Button>
+        </DialogClose>
+        <Button type="button" onClick={onApply} disabled={!canApply || isWorking}>
+          {m.client_setup_apply()}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+}
+
+function ToolSetupDialog(props: ToolSetupDialogProps) {
+  return (
+    <Dialog>
+      <ToolSetupRow
+        title={props.title}
+        description={props.description}
+        summary={props.summary}
+        action={props.action}
+      />
+      <ToolSetupModal
+        title={props.title}
+        description={props.description}
+        action={props.action}
+        canApply={props.canApply}
+        isWorking={props.isWorking}
+        onApply={props.onApply}
+      >
+        {props.children}
+      </ToolSetupModal>
+    </Dialog>
+  );
+}
+
+function ClaudeSetupDetails({ setup }: { setup: ClientSetupInfo }) {
+  return (
+    <div className="space-y-4">
+      <DetailSection label={m.client_setup_target_file_label()}>
+        <PathList paths={[setup.claude_settings_path]} />
+      </DetailSection>
+      <DetailSection label={m.client_setup_effective_env_label()}>
+        <CodeBlock
+          lines={[
+            `ANTHROPIC_BASE_URL=${setup.claude_base_url}`,
+            `ANTHROPIC_AUTH_TOKEN=${
+              setup.claude_auth_token_configured ? "••••••••" : m.client_setup_not_configured()
+            }`,
+          ]}
+        />
+      </DetailSection>
+    </div>
+  );
+}
+
+function CodexSetupDetails({ setup }: { setup: ClientSetupInfo }) {
+  return (
+    <div className="space-y-4">
+      <DetailSection label={m.client_setup_target_file_label()}>
+        <PathList paths={[setup.codex_config_path, setup.codex_auth_path]} />
+      </DetailSection>
+      <DetailSection label={m.client_setup_effective_config_label()}>
+        <CodeBlock
+          lines={[
+            `disable_response_storage = ${setup.codex_disable_response_storage ? "true" : "false"}`,
+            `model = "${setup.codex_model}"`,
+            `model_provider = "${setup.codex_model_provider}"`,
+            `model_reasoning_effort = "${setup.codex_model_reasoning_effort}"`,
+            `network_access = "${setup.codex_network_access}"`,
+            `preferred_auth_method = "${setup.codex_preferred_auth_method}"`,
+            `[model_providers.${setup.codex_model_provider}]`,
+            `base_url = "${setup.codex_provider_base_url}"`,
+            `name = "${setup.codex_provider_name}"`,
+            `requires_openai_auth = ${setup.codex_provider_requires_openai_auth ? "true" : "false"}`,
+            `wire_api = "${setup.codex_provider_wire_api}"`,
+            `auth.json: OPENAI_API_KEY = "${
+              setup.codex_api_key_configured ? "••••••••" : m.client_setup_not_configured()
+            }"`,
+          ]}
+        />
+      </DetailSection>
+    </div>
+  );
+}
+
+function OpenCodeModels({ models }: { models: readonly string[] }) {
+  if (models.length === 0) {
+    return (
+      <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+        {m.client_setup_opencode_models_empty()}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {models.map((model) => (
+        <Badge key={model} variant="outline" className="font-mono text-xs">
+          {model}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function OpenCodeSetupDetails({ setup }: { setup: ClientSetupInfo }) {
+  return (
+    <div className="space-y-4">
+      <DetailSection label={m.client_setup_target_file_label()}>
+        <PathList paths={[setup.opencode_config_path, setup.opencode_auth_path]} />
+      </DetailSection>
+      <DetailSection label={m.client_setup_effective_config_label()}>
+        <CodeBlock
+          lines={[
+            `provider.${setup.opencode_provider_id}.npm = "@ai-sdk/openai-compatible"`,
+            `provider.${setup.opencode_provider_id}.options.baseURL = "${setup.opencode_provider_base_url}"`,
+            `auth.json: ${setup.opencode_provider_id}.key = "${
+              setup.opencode_api_key_configured ? "••••••••" : m.client_setup_not_configured()
+            }"`,
+          ]}
+        />
+      </DetailSection>
+      <DetailSection label={m.client_setup_opencode_models_label()}>
+        <OpenCodeModels models={setup.opencode_models} />
+      </DetailSection>
+    </div>
+  );
+}
+
+type WriteCommand = "write_claude_code_settings" | "write_codex_config" | "write_opencode_config";
+
+function useClientSetupPreview(savedAt: string) {
   const [previewState, setPreviewState] = useState<RequestState>("idle");
   const [previewMessage, setPreviewMessage] = useState("");
   const [setup, setSetup] = useState<ClientSetupInfo | null>(null);
-  const [claudeAction, setClaudeAction] = useState<ActionState>(toActionState);
-  const [codexAction, setCodexAction] = useState<ActionState>(toActionState);
-  const [opencodeAction, setOpencodeAction] = useState<ActionState>(toActionState);
-
-  const canApply = useMemo(() => !isDirty, [isDirty]);
-  const isWorking =
-    previewState === "working" ||
-    claudeAction.state === "working" ||
-    codexAction.state === "working" ||
-    opencodeAction.state === "working";
 
   const loadPreview = useCallback(async () => {
     setPreviewState("working");
@@ -101,60 +359,153 @@ export function ClientSetupCard({ savedAt, isDirty }: ClientSetupCardProps) {
     void loadPreview();
   }, [loadPreview, savedAt]);
 
-  const applyClaudeConfig = useCallback(async () => {
-    setClaudeAction({ state: "working", message: "", lastPath: "" });
+  return { previewState, previewMessage, setup, loadPreview };
+}
+
+function useWriteAction(command: WriteCommand, loadPreview: () => Promise<void>) {
+  const [action, setAction] = useState<ActionState>(toActionState);
+
+  const apply = useCallback(async () => {
+    setAction({ state: "working", message: "", lastPath: "" });
     try {
-      const result = await invoke<ClientConfigWriteResult>("write_claude_code_settings");
+      const result = await invoke<ClientConfigWriteResult>(command);
       const path = result.paths.join(", ");
-      setClaudeAction({
-        state: "success",
-        message: m.client_setup_apply_success({ path }),
-        lastPath: path,
-      });
+      setAction({ state: "success", message: m.client_setup_apply_success({ path }), lastPath: path });
       await loadPreview();
     } catch (error) {
-      setClaudeAction({ state: "error", message: parseError(error), lastPath: "" });
+      setAction({ state: "error", message: parseError(error), lastPath: "" });
     }
-  }, [loadPreview]);
+  }, [command, loadPreview]);
 
-  const applyCodexConfig = useCallback(async () => {
-    setCodexAction({ state: "working", message: "", lastPath: "" });
-    try {
-      const result = await invoke<ClientConfigWriteResult>("write_codex_config");
-      const path = result.paths.join(", ");
-      setCodexAction({
-        state: "success",
-        message: m.client_setup_apply_success({ path }),
-        lastPath: path,
-      });
-      await loadPreview();
-    } catch (error) {
-      setCodexAction({ state: "error", message: parseError(error), lastPath: "" });
-    }
-  }, [loadPreview]);
+  return { action, apply };
+}
 
-  const applyOpenCodeConfig = useCallback(async () => {
-    setOpencodeAction({ state: "working", message: "", lastPath: "" });
-    try {
-      const result = await invoke<ClientConfigWriteResult>("write_opencode_config");
-      const path = result.paths.join(", ");
-      setOpencodeAction({
-        state: "success",
-        message: m.client_setup_apply_success({ path }),
-        lastPath: path,
-      });
-      await loadPreview();
-    } catch (error) {
-      setOpencodeAction({ state: "error", message: parseError(error), lastPath: "" });
-    }
-  }, [loadPreview]);
+type ToolListItem = {
+  id: string;
+  title: string;
+  description: string;
+  summary: ReactNode;
+  content: ReactNode;
+  action: ActionState;
+  canApply: boolean;
+  isWorking: boolean;
+  onApply: () => void;
+};
 
-  const opencodeModels = useMemo(() => setup?.opencode_models ?? [], [setup?.opencode_models]);
-  const canApplyOpenCode = useMemo(
-    () => canApply && opencodeModels.length > 0,
-    [canApply, opencodeModels.length]
+type ClientSetupOverviewProps = {
+  previewState: RequestState;
+  previewMessage: string;
+  setup: ClientSetupInfo | null;
+  isDirty: boolean;
+  isWorking: boolean;
+  onRefresh: () => void;
+};
+
+function ClientSetupOverview({
+  previewState,
+  previewMessage,
+  setup,
+  isDirty,
+  isWorking,
+  onRefresh,
+}: ClientSetupOverviewProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={toBadgeVariant(previewState)}>{toBadgeLabel(previewState)}</Badge>
+        <Button type="button" variant="outline" size="sm" onClick={onRefresh} disabled={isWorking}>
+          {m.common_refresh()}
+        </Button>
+      </div>
+
+      {previewMessage ? (
+        <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+          {previewMessage}
+        </div>
+      ) : null}
+
+      {isDirty ? (
+        <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+          {m.client_setup_dirty_notice()}
+        </div>
+      ) : null}
+
+      {setup ? (
+        <div className="rounded-md border border-border/60 bg-background/60 p-3">
+          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+            {m.client_setup_proxy_base_url_label()}
+          </p>
+          <p className="mt-1 font-mono text-xs text-foreground/80">{setup.proxy_http_base_url}</p>
+        </div>
+      ) : null}
+    </div>
   );
+}
 
+function ToolDetailsFallback({ previewState, previewMessage }: { previewState: RequestState; previewMessage: string }) {
+  if (previewMessage) {
+    return (
+      <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+        {previewMessage}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+      {toBadgeLabel(previewState)}
+    </div>
+  );
+}
+
+function ClientSetupToolList({ tools }: { tools: readonly ToolListItem[] }) {
+  return (
+    <div className="space-y-2">
+      {tools.map((tool) => (
+        <ToolSetupDialog
+          key={tool.id}
+          title={tool.title}
+          description={tool.description}
+          summary={tool.summary}
+          action={tool.action}
+          canApply={tool.canApply}
+          isWorking={tool.isWorking}
+          onApply={tool.onApply}
+        >
+          {tool.content}
+        </ToolSetupDialog>
+      ))}
+    </div>
+  );
+}
+
+function PlaintextWarning() {
+  return (
+    <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+      {m.client_setup_plaintext_warning()}
+    </div>
+  );
+}
+
+type ClientSetupCardLayoutProps = {
+  previewState: RequestState;
+  previewMessage: string;
+  setup: ClientSetupInfo | null;
+  isDirty: boolean;
+  isWorking: boolean;
+  onRefresh: () => void;
+  tools: readonly ToolListItem[];
+};
+
+function ClientSetupCardLayout({
+  previewState,
+  previewMessage,
+  setup,
+  isDirty,
+  isWorking,
+  onRefresh,
+  tools,
+}: ClientSetupCardLayoutProps) {
   return (
     <Card data-slot="client-setup-card">
       <CardHeader>
@@ -162,233 +513,186 @@ export function ClientSetupCard({ savedAt, isDirty }: ClientSetupCardProps) {
         <CardDescription>{m.client_setup_desc()}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <Badge variant={toBadgeVariant(previewState)}>{toBadgeLabel(previewState)}</Badge>
-          <Button type="button" variant="outline" size="sm" onClick={loadPreview} disabled={isWorking}>
-            {m.common_refresh()}
-          </Button>
-        </div>
-
-        {previewMessage ? (
-          <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-            {previewMessage}
-          </div>
-        ) : null}
-
-        {isDirty ? (
-          <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-            {m.client_setup_dirty_notice()}
-          </div>
-        ) : null}
-
-        {setup ? (
-          <div className="rounded-md border border-border/60 bg-background/60 p-3">
-            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-              {m.client_setup_proxy_base_url_label()}
-            </p>
-            <p className="mt-1 font-mono text-xs text-foreground/80">
-              {setup.proxy_http_base_url}
-            </p>
-          </div>
-        ) : null}
-
-        <div className="grid gap-4 lg:grid-cols-3">
-          <Card data-slot="client-setup-tool-claude" className="border-border/60 bg-background/60">
-            <CardHeader>
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <CardTitle className="text-base">{m.client_setup_claude_title()}</CardTitle>
-                  <CardDescription>{m.client_setup_claude_desc()}</CardDescription>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Badge variant={toBadgeVariant(claudeAction.state)}>{toBadgeLabel(claudeAction.state)}</Badge>
-                  <Button type="button" onClick={applyClaudeConfig} disabled={!canApply || isWorking || !setup}>
-                    {m.client_setup_apply()}
-                  </Button>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {setup ? (
-                <div className="space-y-2">
-                  <div className="space-y-1">
-                    <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                      {m.client_setup_target_file_label()}
-                    </p>
-                    <p className="font-mono text-xs text-foreground/80">{setup.claude_settings_path}</p>
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                      {m.client_setup_effective_env_label()}
-                    </p>
-                    <div className="space-y-1 font-mono text-xs text-foreground/80">
-                      <div>ANTHROPIC_BASE_URL={setup.claude_base_url}</div>
-                      <div>
-                        ANTHROPIC_AUTH_TOKEN=
-                        {setup.claude_auth_token_configured ? "••••••••" : m.client_setup_not_configured()}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-
-              {claudeAction.message ? (
-                <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-                  {claudeAction.message}
-                </div>
-              ) : null}
-
-              <p className="text-xs text-muted-foreground">{m.client_setup_backup_hint()}</p>
-            </CardContent>
-          </Card>
-
-          <Card data-slot="client-setup-tool-codex" className="border-border/60 bg-background/60">
-            <CardHeader>
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <CardTitle className="text-base">{m.client_setup_codex_title()}</CardTitle>
-                  <CardDescription>{m.client_setup_codex_desc()}</CardDescription>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Badge variant={toBadgeVariant(codexAction.state)}>{toBadgeLabel(codexAction.state)}</Badge>
-                  <Button type="button" onClick={applyCodexConfig} disabled={!canApply || isWorking || !setup}>
-                    {m.client_setup_apply()}
-                  </Button>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {setup ? (
-                <div className="space-y-2">
-                  <div className="space-y-1">
-                    <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                      {m.client_setup_target_file_label()}
-                    </p>
-                    <p className="font-mono text-xs text-foreground/80">{setup.codex_config_path}</p>
-                    <p className="font-mono text-xs text-foreground/80">{setup.codex_auth_path}</p>
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                      {m.client_setup_effective_config_label()}
-                    </p>
-                    <div className="space-y-1 font-mono text-xs text-foreground/80">
-                      <div>disable_response_storage = {setup.codex_disable_response_storage ? "true" : "false"}</div>
-                      <div>model = "{setup.codex_model}"</div>
-                      <div>model_provider = "{setup.codex_model_provider}"</div>
-                      <div>model_reasoning_effort = "{setup.codex_model_reasoning_effort}"</div>
-                      <div>network_access = "{setup.codex_network_access}"</div>
-                      <div>preferred_auth_method = "{setup.codex_preferred_auth_method}"</div>
-                      <div>[model_providers.{setup.codex_model_provider}]</div>
-                      <div>base_url = "{setup.codex_provider_base_url}"</div>
-                      <div>name = "{setup.codex_provider_name}"</div>
-                      <div>
-                        requires_openai_auth = {setup.codex_provider_requires_openai_auth ? "true" : "false"}
-                      </div>
-                      <div>wire_api = "{setup.codex_provider_wire_api}"</div>
-                      <div>
-                        {`auth.json: OPENAI_API_KEY = "${
-                          setup.codex_api_key_configured
-                            ? "••••••••"
-                            : m.client_setup_not_configured()
-                        }"`}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-
-              {codexAction.message ? (
-                <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-                  {codexAction.message}
-                </div>
-              ) : null}
-
-              <p className="text-xs text-muted-foreground">{m.client_setup_backup_hint()}</p>
-            </CardContent>
-          </Card>
-
-          <Card data-slot="client-setup-tool-opencode" className="border-border/60 bg-background/60">
-            <CardHeader>
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <CardTitle className="text-base">{m.client_setup_opencode_title()}</CardTitle>
-                  <CardDescription>{m.client_setup_opencode_desc()}</CardDescription>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Badge variant={toBadgeVariant(opencodeAction.state)}>{toBadgeLabel(opencodeAction.state)}</Badge>
-                  <Button
-                    type="button"
-                    onClick={applyOpenCodeConfig}
-                    disabled={!canApplyOpenCode || isWorking || !setup}
-                  >
-                    {m.client_setup_apply()}
-                  </Button>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {setup ? (
-                <div className="space-y-2">
-                  <div className="space-y-1">
-                    <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                      {m.client_setup_target_file_label()}
-                    </p>
-                    <p className="font-mono text-xs text-foreground/80">{setup.opencode_config_path}</p>
-                    <p className="font-mono text-xs text-foreground/80">{setup.opencode_auth_path}</p>
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                      {m.client_setup_effective_config_label()}
-                    </p>
-                    <div className="space-y-1 font-mono text-xs text-foreground/80">
-                      <div>provider.{setup.opencode_provider_id}.npm = "@ai-sdk/openai-compatible"</div>
-                      <div>provider.{setup.opencode_provider_id}.options.baseURL = "{setup.opencode_provider_base_url}"</div>
-                      <div>
-                        {`auth.json: ${setup.opencode_provider_id}.key = "${
-                          setup.opencode_api_key_configured ? "••••••••" : m.client_setup_not_configured()
-                        }"`}
-                      </div>
-                    </div>
-                  </div>
-
-                  {setup.opencode_models.length > 0 ? (
-                    <div className="space-y-1">
-                      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                        {m.client_setup_opencode_models_label()}
-                      </p>
-                      <div className="flex flex-wrap gap-1.5">
-                        {setup.opencode_models.map((model) => (
-                          <Badge key={model} variant="outline" className="font-mono text-xs">
-                            {model}
-                          </Badge>
-                        ))}
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-                      {m.client_setup_opencode_models_empty()}
-                    </div>
-                  )}
-                </div>
-              ) : null}
-
-              {opencodeAction.message ? (
-                <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-                  {opencodeAction.message}
-                </div>
-              ) : null}
-
-              <p className="text-xs text-muted-foreground">{m.client_setup_backup_hint()}</p>
-            </CardContent>
-          </Card>
-        </div>
-
+        <ClientSetupOverview
+          previewState={previewState}
+          previewMessage={previewMessage}
+          setup={setup}
+          isDirty={isDirty}
+          isWorking={isWorking}
+          onRefresh={onRefresh}
+        />
+        <ClientSetupToolList tools={tools} />
         <Separator />
-
-        <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-          {m.client_setup_plaintext_warning()}
-        </div>
+        <PlaintextWarning />
       </CardContent>
     </Card>
+  );
+}
+
+type ToolBuildBaseArgs = {
+  setup: ClientSetupInfo | null;
+  previewState: RequestState;
+  previewMessage: string;
+  canApply: boolean;
+  isWorking: boolean;
+};
+
+type ToolBuildActionArgs = {
+  action: ActionState;
+  onApply: () => void;
+};
+
+function buildClaudeTool({
+  setup,
+  previewState,
+  previewMessage,
+  canApply,
+  isWorking,
+  action,
+  onApply,
+}: ToolBuildBaseArgs & ToolBuildActionArgs) {
+  return {
+    id: "claude",
+    title: m.client_setup_claude_title(),
+    description: m.client_setup_claude_desc(),
+    summary: (
+      <SummaryItem
+        label={m.client_setup_target_file_label()}
+        value={setup?.claude_settings_path ?? "—"}
+      />
+    ),
+    content: setup ? (
+      <ClaudeSetupDetails setup={setup} />
+    ) : (
+      <ToolDetailsFallback previewState={previewState} previewMessage={previewMessage} />
+    ),
+    action,
+    canApply: Boolean(setup) && canApply,
+    isWorking,
+    onApply,
+  } satisfies ToolListItem;
+}
+
+function buildCodexTool({
+  setup,
+  previewState,
+  previewMessage,
+  canApply,
+  isWorking,
+  action,
+  onApply,
+}: ToolBuildBaseArgs & ToolBuildActionArgs) {
+  return {
+    id: "codex",
+    title: m.client_setup_codex_title(),
+    description: m.client_setup_codex_desc(),
+    summary: (
+      <SummaryItem
+        label={m.client_setup_target_file_label()}
+        value={setup ? `${setup.codex_config_path} (+1)` : "—"}
+      />
+    ),
+    content: setup ? (
+      <CodexSetupDetails setup={setup} />
+    ) : (
+      <ToolDetailsFallback previewState={previewState} previewMessage={previewMessage} />
+    ),
+    action,
+    canApply: Boolean(setup) && canApply,
+    isWorking,
+    onApply,
+  } satisfies ToolListItem;
+}
+
+type OpenCodeToolArgs = ToolBuildBaseArgs & ToolBuildActionArgs & {
+  openCodeModelCount: number;
+  canApplyOpenCode: boolean;
+};
+
+function buildOpenCodeTool({
+  setup,
+  previewState,
+  previewMessage,
+  canApplyOpenCode,
+  openCodeModelCount,
+  isWorking,
+  action,
+  onApply,
+}: OpenCodeToolArgs) {
+  return {
+    id: "opencode",
+    title: m.client_setup_opencode_title(),
+    description: m.client_setup_opencode_desc(),
+    summary: (
+      <div className="space-y-1">
+        <SummaryItem
+          label={m.client_setup_target_file_label()}
+          value={setup ? `${setup.opencode_config_path} (+1)` : "—"}
+        />
+        <SummaryItem
+          label={m.client_setup_opencode_models_label()}
+          value={setup ? String(openCodeModelCount) : "—"}
+        />
+      </div>
+    ),
+    content: setup ? (
+      <OpenCodeSetupDetails setup={setup} />
+    ) : (
+      <ToolDetailsFallback previewState={previewState} previewMessage={previewMessage} />
+    ),
+    action,
+    canApply: Boolean(setup) && canApplyOpenCode,
+    isWorking,
+    onApply,
+  } satisfies ToolListItem;
+}
+
+export function ClientSetupCard({ savedAt, isDirty }: ClientSetupCardProps) {
+  const canApply = !isDirty;
+  const { previewState, previewMessage, setup, loadPreview } = useClientSetupPreview(savedAt);
+
+  const claude = useWriteAction("write_claude_code_settings", loadPreview);
+  const codex = useWriteAction("write_codex_config", loadPreview);
+  const opencode = useWriteAction("write_opencode_config", loadPreview);
+
+  const isWorking =
+    previewState === "working" ||
+    claude.action.state === "working" ||
+    codex.action.state === "working" ||
+    opencode.action.state === "working";
+
+  const openCodeModelCount = setup?.opencode_models.length ?? 0;
+  const canApplyOpenCode = canApply && openCodeModelCount > 0;
+
+  const baseArgs: ToolBuildBaseArgs = {
+    setup,
+    previewState,
+    previewMessage,
+    canApply,
+    isWorking,
+  };
+
+  const tools: ToolListItem[] = [
+    buildClaudeTool({ ...baseArgs, action: claude.action, onApply: claude.apply }),
+    buildCodexTool({ ...baseArgs, action: codex.action, onApply: codex.apply }),
+    buildOpenCodeTool({
+      ...baseArgs,
+      action: opencode.action,
+      onApply: opencode.apply,
+      openCodeModelCount,
+      canApplyOpenCode,
+    }),
+  ];
+
+  return (
+    <ClientSetupCardLayout
+      previewState={previewState}
+      previewMessage={previewMessage}
+      setup={setup}
+      isDirty={isDirty}
+      isWorking={isWorking}
+      onRefresh={loadPreview}
+      tools={tools}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Replace the cramped 3-column Agents setup grid with list rows and per-tool modals.
- Add a reusable Dialog component for centered configuration/apply flows.

## Why
The Agents page columns were crowded and visually distorted, especially with long paths and config lines. The new UX keeps the default view compact (one row per tool) and moves detailed settings/apply into a modal as requested.

## What changed
- Added `src/components/ui/dialog.tsx` based on Radix Dialog.
- Refactored `ClientSetupCard` into overview, tool rows, and modal detail components.
- Render long paths/configs line-by-line with scroll containers to prevent layout breakage.

## Implementation details
- Preview and write actions are encapsulated in small hooks for clarity.
- Tool rows are built via helper builders (Claude/Codex/OpenCode) to keep logic single-source.
- Existing behavior is preserved (refresh, apply, OpenCode model gating).

## Testing
- `pnpm run i18n:compile`
- `pnpm tsc --noEmit`
- `pnpm run build`
