### PR TITLE
Split Agents auto-setup into overview and tool cards

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -39,7 +39,7 @@
   "config_section_upstreams_label": "Upstreams",
   "config_section_upstreams_desc": "Provider pools and API keys",
   "config_section_agents_label": "Agents",
-  "config_section_agents_desc": "Claude Code / Codex / OpenCode auto-setup",
+  "config_section_agents_desc": "Agents auto-setup",
   "config_section_settings_label": "Settings",
   "config_section_settings_desc": "Config file, validation, and updates",
 
@@ -158,7 +158,7 @@
   "project_links_github_label": "GitHub",
   "project_links_open": "Open",
 
-  "client_setup_title": "Claude Code / Codex / OpenCode Auto Setup",
+  "client_setup_title": "Agents Auto Setup",
   "client_setup_desc": "Write local config files so tools can use Token Proxy directly.",
   "client_setup_proxy_base_url_label": "Proxy Base URL",
   "client_setup_dirty_notice": "You have unsaved proxy changes. Save first to avoid writing stale settings.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -36,7 +36,7 @@
   "config_section_upstreams_label": "上游",
   "config_section_upstreams_desc": "提供商池与 API Key",
   "config_section_agents_label": "Agents",
-  "config_section_agents_desc": "Claude Code / Codex / OpenCode 自动配置",
+  "config_section_agents_desc": "Agents自动配置",
   "config_section_settings_label": "设置",
   "config_section_settings_desc": "配置文件、校验与更新",
   "proxy_core_title": "内核",
@@ -150,7 +150,7 @@
   "project_links_github_label": "GitHub",
   "project_links_open": "打开",
 
-  "client_setup_title": "Claude Code / Codex / OpenCode 自动配置",
+  "client_setup_title": "Agents自动配置",
   "client_setup_desc": "一键写入本机配置文件，让工具直接接入 Token Proxy。",
   "client_setup_proxy_base_url_label": "代理 Base URL",
   "client_setup_dirty_notice": "检测到未保存的代理配置。请先保存，避免写入过期的接入信息。",

--- a/src/features/config/cards/client-setup-card.tsx
+++ b/src/features/config/cards/client-setup-card.tsx
@@ -1,384 +1,31 @@
-import { useCallback, useEffect, useState, type ReactNode } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import type { ReactNode } from "react";
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogBody,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Separator } from "@/components/ui/separator";
-import { parseError } from "@/lib/error";
 import { m } from "@/paraglide/messages.js";
 
-type ClientSetupInfo = {
-  proxy_http_base_url: string;
-  claude_settings_path: string;
-  claude_base_url: string;
-  claude_auth_token_configured: boolean;
-  codex_config_path: string;
-  codex_auth_path: string;
-  codex_disable_response_storage: boolean;
-  codex_model: string;
-  codex_model_provider: string;
-  codex_model_reasoning_effort: string;
-  codex_network_access: string;
-  codex_preferred_auth_method: string;
-  codex_provider_base_url: string;
-  codex_provider_name: string;
-  codex_provider_requires_openai_auth: boolean;
-  codex_provider_wire_api: string;
-  codex_api_key_configured: boolean;
-  opencode_config_path: string;
-  opencode_auth_path: string;
-  opencode_provider_id: string;
-  opencode_provider_base_url: string;
-  opencode_models: string[];
-  opencode_api_key_configured: boolean;
-};
-
-type ClientConfigWriteResult = {
-  paths: string[];
-};
-
-type RequestState = "idle" | "working" | "success" | "error";
-
-type ActionState = {
-  state: RequestState;
-  message: string;
-  lastPath: string;
-};
-
-function toActionState(): ActionState {
-  return { state: "idle", message: "", lastPath: "" };
-}
-
-function toBadgeVariant(state: RequestState) {
-  if (state === "success") return "default";
-  if (state === "error") return "destructive";
-  if (state === "working") return "secondary";
-  return "outline";
-}
-
-function toBadgeLabel(state: RequestState) {
-  if (state === "success") return m.client_setup_status_success();
-  if (state === "error") return m.client_setup_status_error();
-  if (state === "working") return m.client_setup_status_working();
-  return m.client_setup_status_idle();
-}
+import {
+  ClientSetupOverviewCard,
+  PlaintextWarning,
+  SummaryItem,
+  ToolDetailsFallback,
+  ToolSetupDialog,
+} from "./client-setup-ui";
+import {
+  useClientSetupPreview,
+  useWriteAction,
+  type ActionState,
+  type ClientSetupInfo,
+  type RequestState,
+} from "./client-setup-state";
+import {
+  ClaudeSetupDetails,
+  CodexSetupDetails,
+  OpenCodeSetupDetails,
+} from "./client-setup-details";
 
 type ClientSetupCardProps = {
   savedAt: string;
   isDirty: boolean;
 };
-
-type ToolSetupDialogProps = {
-  title: string;
-  description: string;
-  summary: ReactNode;
-  action: ActionState;
-  canApply: boolean;
-  isWorking: boolean;
-  onApply: () => void;
-  children: ReactNode;
-};
-
-function SummaryItem({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-      <span className="shrink-0 uppercase tracking-[0.2em]">{label}</span>
-      <span className="min-w-0 truncate font-mono text-foreground/80">{value}</span>
-    </div>
-  );
-}
-
-function DetailSection({ label, children }: { label: string; children: ReactNode }) {
-  return (
-    <div className="space-y-1">
-      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{label}</p>
-      {children}
-    </div>
-  );
-}
-
-function MonoBlock({ children }: { children: ReactNode }) {
-  return (
-    <div className="rounded-md border border-border/60 bg-background/60 p-3">
-      {children}
-    </div>
-  );
-}
-
-function PathList({ paths }: { paths: readonly string[] }) {
-  return (
-    <MonoBlock>
-      <div className="space-y-1 font-mono text-xs text-foreground/80 break-all">
-        {paths.map((path, index) => (
-          <div key={index}>{path}</div>
-        ))}
-      </div>
-    </MonoBlock>
-  );
-}
-
-function CodeBlock({ lines }: { lines: readonly string[] }) {
-  return (
-    <MonoBlock>
-      <div className="overflow-x-auto">
-        <div className="min-w-max space-y-1 font-mono text-xs text-foreground/80 whitespace-pre">
-          {lines.map((line, index) => (
-            <div key={index}>{line}</div>
-          ))}
-        </div>
-      </div>
-    </MonoBlock>
-  );
-}
-
-type ToolSetupRowProps = Pick<ToolSetupDialogProps, "title" | "description" | "summary" | "action">;
-
-function ToolSetupRow({ title, description, summary, action }: ToolSetupRowProps) {
-  return (
-    <div className="rounded-md border border-border/60 bg-background/60 p-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0 space-y-2">
-          <div className="space-y-0.5">
-            <p className="truncate text-sm font-medium text-foreground">{title}</p>
-            <p className="text-xs text-muted-foreground">{description}</p>
-          </div>
-          {summary}
-        </div>
-        <div className="flex items-center gap-2">
-          <Badge variant={toBadgeVariant(action.state)}>{toBadgeLabel(action.state)}</Badge>
-          <DialogTrigger asChild>
-            <Button type="button" variant="outline" size="sm">
-              {m.common_show()}
-            </Button>
-          </DialogTrigger>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-type ToolSetupModalProps = Omit<ToolSetupDialogProps, "summary">;
-
-function ToolSetupModal({
-  title,
-  description,
-  action,
-  canApply,
-  isWorking,
-  onApply,
-  children,
-}: ToolSetupModalProps) {
-  return (
-    <DialogContent className="max-w-2xl">
-      <DialogHeader>
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <DialogTitle>{title}</DialogTitle>
-            <DialogDescription>{description}</DialogDescription>
-          </div>
-          <Badge variant={toBadgeVariant(action.state)}>{toBadgeLabel(action.state)}</Badge>
-        </div>
-      </DialogHeader>
-
-      <DialogBody className="space-y-4">
-        {children}
-
-        {action.message ? (
-          <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-            {action.message}
-          </div>
-        ) : null}
-
-        <p className="text-xs text-muted-foreground">{m.client_setup_backup_hint()}</p>
-      </DialogBody>
-
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button type="button" variant="outline">
-            {m.common_close()}
-          </Button>
-        </DialogClose>
-        <Button type="button" onClick={onApply} disabled={!canApply || isWorking}>
-          {m.client_setup_apply()}
-        </Button>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-function ToolSetupDialog(props: ToolSetupDialogProps) {
-  return (
-    <Dialog>
-      <ToolSetupRow
-        title={props.title}
-        description={props.description}
-        summary={props.summary}
-        action={props.action}
-      />
-      <ToolSetupModal
-        title={props.title}
-        description={props.description}
-        action={props.action}
-        canApply={props.canApply}
-        isWorking={props.isWorking}
-        onApply={props.onApply}
-      >
-        {props.children}
-      </ToolSetupModal>
-    </Dialog>
-  );
-}
-
-function ClaudeSetupDetails({ setup }: { setup: ClientSetupInfo }) {
-  return (
-    <div className="space-y-4">
-      <DetailSection label={m.client_setup_target_file_label()}>
-        <PathList paths={[setup.claude_settings_path]} />
-      </DetailSection>
-      <DetailSection label={m.client_setup_effective_env_label()}>
-        <CodeBlock
-          lines={[
-            `ANTHROPIC_BASE_URL=${setup.claude_base_url}`,
-            `ANTHROPIC_AUTH_TOKEN=${
-              setup.claude_auth_token_configured ? "••••••••" : m.client_setup_not_configured()
-            }`,
-          ]}
-        />
-      </DetailSection>
-    </div>
-  );
-}
-
-function CodexSetupDetails({ setup }: { setup: ClientSetupInfo }) {
-  return (
-    <div className="space-y-4">
-      <DetailSection label={m.client_setup_target_file_label()}>
-        <PathList paths={[setup.codex_config_path, setup.codex_auth_path]} />
-      </DetailSection>
-      <DetailSection label={m.client_setup_effective_config_label()}>
-        <CodeBlock
-          lines={[
-            `disable_response_storage = ${setup.codex_disable_response_storage ? "true" : "false"}`,
-            `model = "${setup.codex_model}"`,
-            `model_provider = "${setup.codex_model_provider}"`,
-            `model_reasoning_effort = "${setup.codex_model_reasoning_effort}"`,
-            `network_access = "${setup.codex_network_access}"`,
-            `preferred_auth_method = "${setup.codex_preferred_auth_method}"`,
-            `[model_providers.${setup.codex_model_provider}]`,
-            `base_url = "${setup.codex_provider_base_url}"`,
-            `name = "${setup.codex_provider_name}"`,
-            `requires_openai_auth = ${setup.codex_provider_requires_openai_auth ? "true" : "false"}`,
-            `wire_api = "${setup.codex_provider_wire_api}"`,
-            `auth.json: OPENAI_API_KEY = "${
-              setup.codex_api_key_configured ? "••••••••" : m.client_setup_not_configured()
-            }"`,
-          ]}
-        />
-      </DetailSection>
-    </div>
-  );
-}
-
-function OpenCodeModels({ models }: { models: readonly string[] }) {
-  if (models.length === 0) {
-    return (
-      <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-        {m.client_setup_opencode_models_empty()}
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-wrap gap-1.5">
-      {models.map((model) => (
-        <Badge key={model} variant="outline" className="font-mono text-xs">
-          {model}
-        </Badge>
-      ))}
-    </div>
-  );
-}
-
-function OpenCodeSetupDetails({ setup }: { setup: ClientSetupInfo }) {
-  return (
-    <div className="space-y-4">
-      <DetailSection label={m.client_setup_target_file_label()}>
-        <PathList paths={[setup.opencode_config_path, setup.opencode_auth_path]} />
-      </DetailSection>
-      <DetailSection label={m.client_setup_effective_config_label()}>
-        <CodeBlock
-          lines={[
-            `provider.${setup.opencode_provider_id}.npm = "@ai-sdk/openai-compatible"`,
-            `provider.${setup.opencode_provider_id}.options.baseURL = "${setup.opencode_provider_base_url}"`,
-            `auth.json: ${setup.opencode_provider_id}.key = "${
-              setup.opencode_api_key_configured ? "••••••••" : m.client_setup_not_configured()
-            }"`,
-          ]}
-        />
-      </DetailSection>
-      <DetailSection label={m.client_setup_opencode_models_label()}>
-        <OpenCodeModels models={setup.opencode_models} />
-      </DetailSection>
-    </div>
-  );
-}
-
-type WriteCommand = "write_claude_code_settings" | "write_codex_config" | "write_opencode_config";
-
-function useClientSetupPreview(savedAt: string) {
-  const [previewState, setPreviewState] = useState<RequestState>("idle");
-  const [previewMessage, setPreviewMessage] = useState("");
-  const [setup, setSetup] = useState<ClientSetupInfo | null>(null);
-
-  const loadPreview = useCallback(async () => {
-    setPreviewState("working");
-    setPreviewMessage("");
-    try {
-      const result = await invoke<ClientSetupInfo>("preview_client_setup");
-      setSetup(result);
-      setPreviewState("success");
-    } catch (error) {
-      setPreviewState("error");
-      setPreviewMessage(parseError(error));
-    }
-  }, []);
-
-  useEffect(() => {
-    void loadPreview();
-  }, [loadPreview, savedAt]);
-
-  return { previewState, previewMessage, setup, loadPreview };
-}
-
-function useWriteAction(command: WriteCommand, loadPreview: () => Promise<void>) {
-  const [action, setAction] = useState<ActionState>(toActionState);
-
-  const apply = useCallback(async () => {
-    setAction({ state: "working", message: "", lastPath: "" });
-    try {
-      const result = await invoke<ClientConfigWriteResult>(command);
-      const path = result.paths.join(", ");
-      setAction({ state: "success", message: m.client_setup_apply_success({ path }), lastPath: path });
-      await loadPreview();
-    } catch (error) {
-      setAction({ state: "error", message: parseError(error), lastPath: "" });
-    }
-  }, [command, loadPreview]);
-
-  return { action, apply };
-}
 
 type ToolListItem = {
   id: string;
@@ -391,143 +38,6 @@ type ToolListItem = {
   isWorking: boolean;
   onApply: () => void;
 };
-
-type ClientSetupOverviewProps = {
-  previewState: RequestState;
-  previewMessage: string;
-  setup: ClientSetupInfo | null;
-  isDirty: boolean;
-  isWorking: boolean;
-  onRefresh: () => void;
-};
-
-function ClientSetupOverview({
-  previewState,
-  previewMessage,
-  setup,
-  isDirty,
-  isWorking,
-  onRefresh,
-}: ClientSetupOverviewProps) {
-  return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant={toBadgeVariant(previewState)}>{toBadgeLabel(previewState)}</Badge>
-        <Button type="button" variant="outline" size="sm" onClick={onRefresh} disabled={isWorking}>
-          {m.common_refresh()}
-        </Button>
-      </div>
-
-      {previewMessage ? (
-        <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-          {previewMessage}
-        </div>
-      ) : null}
-
-      {isDirty ? (
-        <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-          {m.client_setup_dirty_notice()}
-        </div>
-      ) : null}
-
-      {setup ? (
-        <div className="rounded-md border border-border/60 bg-background/60 p-3">
-          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-            {m.client_setup_proxy_base_url_label()}
-          </p>
-          <p className="mt-1 font-mono text-xs text-foreground/80">{setup.proxy_http_base_url}</p>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function ToolDetailsFallback({ previewState, previewMessage }: { previewState: RequestState; previewMessage: string }) {
-  if (previewMessage) {
-    return (
-      <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-        {previewMessage}
-      </div>
-    );
-  }
-
-  return (
-    <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-      {toBadgeLabel(previewState)}
-    </div>
-  );
-}
-
-function ClientSetupToolList({ tools }: { tools: readonly ToolListItem[] }) {
-  return (
-    <div className="space-y-2">
-      {tools.map((tool) => (
-        <ToolSetupDialog
-          key={tool.id}
-          title={tool.title}
-          description={tool.description}
-          summary={tool.summary}
-          action={tool.action}
-          canApply={tool.canApply}
-          isWorking={tool.isWorking}
-          onApply={tool.onApply}
-        >
-          {tool.content}
-        </ToolSetupDialog>
-      ))}
-    </div>
-  );
-}
-
-function PlaintextWarning() {
-  return (
-    <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
-      {m.client_setup_plaintext_warning()}
-    </div>
-  );
-}
-
-type ClientSetupCardLayoutProps = {
-  previewState: RequestState;
-  previewMessage: string;
-  setup: ClientSetupInfo | null;
-  isDirty: boolean;
-  isWorking: boolean;
-  onRefresh: () => void;
-  tools: readonly ToolListItem[];
-};
-
-function ClientSetupCardLayout({
-  previewState,
-  previewMessage,
-  setup,
-  isDirty,
-  isWorking,
-  onRefresh,
-  tools,
-}: ClientSetupCardLayoutProps) {
-  return (
-    <Card data-slot="client-setup-card">
-      <CardHeader>
-        <CardTitle>{m.client_setup_title()}</CardTitle>
-        <CardDescription>{m.client_setup_desc()}</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <ClientSetupOverview
-          previewState={previewState}
-          previewMessage={previewMessage}
-          setup={setup}
-          isDirty={isDirty}
-          isWorking={isWorking}
-          onRefresh={onRefresh}
-        />
-        <ClientSetupToolList tools={tools} />
-        <Separator />
-        <PlaintextWarning />
-      </CardContent>
-    </Card>
-  );
-}
 
 type ToolBuildBaseArgs = {
   setup: ClientSetupInfo | null;
@@ -647,6 +157,27 @@ function buildOpenCodeTool({
   } satisfies ToolListItem;
 }
 
+function ToolCards({ tools }: { tools: readonly ToolListItem[] }) {
+  return (
+    <>
+      {tools.map((tool) => (
+        <ToolSetupDialog
+          key={tool.id}
+          title={tool.title}
+          description={tool.description}
+          summary={tool.summary}
+          action={tool.action}
+          canApply={tool.canApply}
+          isWorking={tool.isWorking}
+          onApply={tool.onApply}
+        >
+          {tool.content}
+        </ToolSetupDialog>
+      ))}
+    </>
+  );
+}
+
 export function ClientSetupCard({ savedAt, isDirty }: ClientSetupCardProps) {
   const canApply = !isDirty;
   const { previewState, previewMessage, setup, loadPreview } = useClientSetupPreview(savedAt);
@@ -685,14 +216,17 @@ export function ClientSetupCard({ savedAt, isDirty }: ClientSetupCardProps) {
   ];
 
   return (
-    <ClientSetupCardLayout
-      previewState={previewState}
-      previewMessage={previewMessage}
-      setup={setup}
-      isDirty={isDirty}
-      isWorking={isWorking}
-      onRefresh={loadPreview}
-      tools={tools}
-    />
+    <>
+      <ClientSetupOverviewCard
+        previewState={previewState}
+        previewMessage={previewMessage}
+        setup={setup}
+        isDirty={isDirty}
+        isWorking={isWorking}
+        onRefresh={loadPreview}
+      />
+      <ToolCards tools={tools} />
+      <PlaintextWarning />
+    </>
   );
 }

--- a/src/features/config/cards/client-setup-details.tsx
+++ b/src/features/config/cards/client-setup-details.tsx
@@ -1,0 +1,104 @@
+import { Badge } from "@/components/ui/badge";
+import { m } from "@/paraglide/messages.js";
+
+import type { ClientSetupInfo } from "./client-setup-state";
+import { CodeBlock, DetailSection, PathList } from "./client-setup-ui";
+
+function OpenCodeModels({ models }: { models: readonly string[] }) {
+  if (models.length === 0) {
+    return (
+      <div
+        data-slot="client-setup-opencode-models"
+        className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground"
+      >
+        {m.client_setup_opencode_models_empty()}
+      </div>
+    );
+  }
+
+  return (
+    <div data-slot="client-setup-opencode-models" className="flex flex-wrap gap-1.5">
+      {models.map((model) => (
+        <Badge key={model} variant="outline" className="font-mono text-xs">
+          {model}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+export function ClaudeSetupDetails({ setup }: { setup: ClientSetupInfo }) {
+  return (
+    <div data-slot="client-setup-claude-details" className="space-y-4">
+      <DetailSection label={m.client_setup_target_file_label()}>
+        <PathList paths={[setup.claude_settings_path]} />
+      </DetailSection>
+      <DetailSection label={m.client_setup_effective_env_label()}>
+        <CodeBlock
+          lines={[
+            `ANTHROPIC_BASE_URL=${setup.claude_base_url}`,
+            `ANTHROPIC_AUTH_TOKEN=${
+              setup.claude_auth_token_configured ? "••••••••" : m.client_setup_not_configured()
+            }`,
+          ]}
+        />
+      </DetailSection>
+    </div>
+  );
+}
+
+export function CodexSetupDetails({ setup }: { setup: ClientSetupInfo }) {
+  return (
+    <div data-slot="client-setup-codex-details" className="space-y-4">
+      <DetailSection label={m.client_setup_target_file_label()}>
+        <PathList paths={[setup.codex_config_path, setup.codex_auth_path]} />
+      </DetailSection>
+      <DetailSection label={m.client_setup_effective_config_label()}>
+        <CodeBlock
+          lines={[
+            `disable_response_storage = ${setup.codex_disable_response_storage ? "true" : "false"}`,
+            `model = "${setup.codex_model}"`,
+            `model_provider = "${setup.codex_model_provider}"`,
+            `model_reasoning_effort = "${setup.codex_model_reasoning_effort}"`,
+            `network_access = "${setup.codex_network_access}"`,
+            `preferred_auth_method = "${setup.codex_preferred_auth_method}"`,
+            `[model_providers.${setup.codex_model_provider}]`,
+            `base_url = "${setup.codex_provider_base_url}"`,
+            `name = "${setup.codex_provider_name}"`,
+            `requires_openai_auth = ${setup.codex_provider_requires_openai_auth ? "true" : "false"}`,
+            `wire_api = "${setup.codex_provider_wire_api}"`,
+            `auth.json: OPENAI_API_KEY = "${
+              setup.codex_api_key_configured ? "••••••••" : m.client_setup_not_configured()
+            }"`,
+          ]}
+        />
+      </DetailSection>
+    </div>
+  );
+}
+
+export function OpenCodeSetupDetails({ setup }: { setup: ClientSetupInfo }) {
+  return (
+    <div data-slot="client-setup-opencode-details" className="space-y-4">
+      <DetailSection label={m.client_setup_target_file_label()}>
+        <PathList paths={[setup.opencode_config_path, setup.opencode_auth_path]} />
+      </DetailSection>
+      <DetailSection label={m.client_setup_effective_config_label()}>
+        <CodeBlock
+          lines={[
+            `provider.${setup.opencode_provider_id}.npm = "@ai-sdk/openai-compatible"`,
+            `provider.${setup.opencode_provider_id}.options.baseURL = "${
+              setup.opencode_provider_base_url
+            }"`,
+            `auth.json: ${setup.opencode_provider_id}.key = "${
+              setup.opencode_api_key_configured ? "••••••••" : m.client_setup_not_configured()
+            }"`,
+          ]}
+        />
+      </DetailSection>
+      <DetailSection label={m.client_setup_opencode_models_label()}>
+        <OpenCodeModels models={setup.opencode_models} />
+      </DetailSection>
+    </div>
+  );
+}

--- a/src/features/config/cards/client-setup-state.ts
+++ b/src/features/config/cards/client-setup-state.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+import { parseError } from "@/lib/error";
+import { m } from "@/paraglide/messages.js";
+
+export type ClientSetupInfo = {
+  proxy_http_base_url: string;
+  claude_settings_path: string;
+  claude_base_url: string;
+  claude_auth_token_configured: boolean;
+  codex_config_path: string;
+  codex_auth_path: string;
+  codex_disable_response_storage: boolean;
+  codex_model: string;
+  codex_model_provider: string;
+  codex_model_reasoning_effort: string;
+  codex_network_access: string;
+  codex_preferred_auth_method: string;
+  codex_provider_base_url: string;
+  codex_provider_name: string;
+  codex_provider_requires_openai_auth: boolean;
+  codex_provider_wire_api: string;
+  codex_api_key_configured: boolean;
+  opencode_config_path: string;
+  opencode_auth_path: string;
+  opencode_provider_id: string;
+  opencode_provider_base_url: string;
+  opencode_models: string[];
+  opencode_api_key_configured: boolean;
+};
+
+type ClientConfigWriteResult = {
+  paths: string[];
+};
+
+export type RequestState = "idle" | "working" | "success" | "error";
+
+export type ActionState = {
+  state: RequestState;
+  message: string;
+  lastPath: string;
+};
+
+export type WriteCommand =
+  | "write_claude_code_settings"
+  | "write_codex_config"
+  | "write_opencode_config";
+
+export function toActionState(): ActionState {
+  return { state: "idle", message: "", lastPath: "" };
+}
+
+export function useClientSetupPreview(savedAt: string) {
+  const [previewState, setPreviewState] = useState<RequestState>("idle");
+  const [previewMessage, setPreviewMessage] = useState("");
+  const [setup, setSetup] = useState<ClientSetupInfo | null>(null);
+
+  const loadPreview = useCallback(async () => {
+    setPreviewState("working");
+    setPreviewMessage("");
+    try {
+      const result = await invoke<ClientSetupInfo>("preview_client_setup");
+      setSetup(result);
+      setPreviewState("success");
+    } catch (error) {
+      setPreviewState("error");
+      setPreviewMessage(parseError(error));
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadPreview();
+  }, [loadPreview, savedAt]);
+
+  return { previewState, previewMessage, setup, loadPreview };
+}
+
+export function useWriteAction(command: WriteCommand, loadPreview: () => Promise<void>) {
+  const [action, setAction] = useState<ActionState>(toActionState);
+
+  const apply = useCallback(async () => {
+    setAction({ state: "working", message: "", lastPath: "" });
+    try {
+      const result = await invoke<ClientConfigWriteResult>(command);
+      const path = result.paths.join(", ");
+      setAction({ state: "success", message: m.client_setup_apply_success({ path }), lastPath: path });
+      await loadPreview();
+    } catch (error) {
+      setAction({ state: "error", message: parseError(error), lastPath: "" });
+    }
+  }, [command, loadPreview]);
+
+  return { action, apply };
+}

--- a/src/features/config/cards/client-setup-ui.tsx
+++ b/src/features/config/cards/client-setup-ui.tsx
@@ -1,0 +1,312 @@
+import type { ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { m } from "@/paraglide/messages.js";
+
+import type { ActionState, ClientSetupInfo, RequestState } from "./client-setup-state";
+
+type ToolSetupDialogProps = {
+  title: string;
+  description: string;
+  summary: ReactNode;
+  action: ActionState;
+  canApply: boolean;
+  isWorking: boolean;
+  onApply: () => void;
+  children: ReactNode;
+};
+
+function shouldShowBadge(state: RequestState) {
+  return state !== "idle";
+}
+
+function toBadgeVariant(state: RequestState) {
+  if (state === "success") return "default";
+  if (state === "error") return "destructive";
+  if (state === "working") return "secondary";
+  return "outline";
+}
+
+function toBadgeLabel(state: RequestState) {
+  if (state === "success") return m.client_setup_status_success();
+  if (state === "error") return m.client_setup_status_error();
+  if (state === "working") return m.client_setup_status_working();
+  return m.client_setup_status_idle();
+}
+
+export function SummaryItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      data-slot="client-setup-summary-item"
+      className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground"
+    >
+      <span className="shrink-0 uppercase tracking-[0.2em]">{label}</span>
+      <span className="min-w-0 truncate font-mono text-foreground/80">{value}</span>
+    </div>
+  );
+}
+
+export function DetailSection({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div data-slot="client-setup-detail-section" className="space-y-1">
+      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+export function MonoBlock({ children }: { children: ReactNode }) {
+  return (
+    <div data-slot="client-setup-mono-block" className="rounded-md border border-border/60 bg-background/60 p-3">
+      {children}
+    </div>
+  );
+}
+
+export function PathList({ paths }: { paths: readonly string[] }) {
+  return (
+    <div data-slot="client-setup-path-list">
+      <MonoBlock>
+        <div className="space-y-1 font-mono text-xs text-foreground/80 break-all">
+          {paths.map((path, index) => (
+            <div key={index}>{path}</div>
+          ))}
+        </div>
+      </MonoBlock>
+    </div>
+  );
+}
+
+export function CodeBlock({ lines }: { lines: readonly string[] }) {
+  return (
+    <div data-slot="client-setup-code-block">
+      <MonoBlock>
+        <div className="overflow-x-auto">
+          <div className="min-w-max space-y-1 font-mono text-xs text-foreground/80 whitespace-pre">
+            {lines.map((line, index) => (
+              <div key={index}>{line}</div>
+            ))}
+          </div>
+        </div>
+      </MonoBlock>
+    </div>
+  );
+}
+
+type ToolSetupCardProps = Pick<ToolSetupDialogProps, "title" | "description" | "summary" | "action">;
+
+function ToolSetupCard({ title, description, summary, action }: ToolSetupCardProps) {
+  return (
+    <Card data-slot="client-setup-tool-card">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle>{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          {shouldShowBadge(action.state) ? (
+            <Badge variant={toBadgeVariant(action.state)}>{toBadgeLabel(action.state)}</Badge>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {summary}
+        <DialogTrigger asChild>
+          <Button type="button" variant="outline" size="sm">
+            {m.common_show()}
+          </Button>
+        </DialogTrigger>
+      </CardContent>
+    </Card>
+  );
+}
+
+type ToolSetupModalProps = Omit<ToolSetupDialogProps, "summary">;
+
+function ToolSetupModal({
+  title,
+  description,
+  action,
+  canApply,
+  isWorking,
+  onApply,
+  children,
+}: ToolSetupModalProps) {
+  return (
+    <DialogContent className="max-w-2xl">
+      <DialogHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </div>
+          {shouldShowBadge(action.state) ? (
+            <Badge variant={toBadgeVariant(action.state)}>{toBadgeLabel(action.state)}</Badge>
+          ) : null}
+        </div>
+      </DialogHeader>
+
+      <DialogBody className="space-y-4">
+        {children}
+
+        {action.message ? (
+          <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+            {action.message}
+          </div>
+        ) : null}
+
+        <p className="text-xs text-muted-foreground">{m.client_setup_backup_hint()}</p>
+      </DialogBody>
+
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button type="button" variant="outline">
+            {m.common_close()}
+          </Button>
+        </DialogClose>
+        <Button type="button" onClick={onApply} disabled={!canApply || isWorking}>
+          {m.client_setup_apply()}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+}
+
+export function ToolSetupDialog(props: ToolSetupDialogProps) {
+  return (
+    <Dialog>
+      <ToolSetupCard
+        title={props.title}
+        description={props.description}
+        summary={props.summary}
+        action={props.action}
+      />
+      <ToolSetupModal
+        title={props.title}
+        description={props.description}
+        action={props.action}
+        canApply={props.canApply}
+        isWorking={props.isWorking}
+        onApply={props.onApply}
+      >
+        {props.children}
+      </ToolSetupModal>
+    </Dialog>
+  );
+}
+
+export function ToolDetailsFallback({
+  previewState,
+  previewMessage,
+}: {
+  previewState: RequestState;
+  previewMessage: string;
+}) {
+  if (previewMessage) {
+    return (
+      <div
+        data-slot="client-setup-details-fallback"
+        className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground"
+      >
+        {previewMessage}
+      </div>
+    );
+  }
+
+  if (previewState === "working" || previewState === "error") {
+    return (
+      <div
+        data-slot="client-setup-details-fallback"
+        className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground"
+      >
+        {toBadgeLabel(previewState)}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export function PlaintextWarning() {
+  return (
+    <div
+      data-slot="client-setup-plaintext-warning"
+      className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground"
+    >
+      {m.client_setup_plaintext_warning()}
+    </div>
+  );
+}
+
+type ClientSetupOverviewCardProps = {
+  previewState: RequestState;
+  previewMessage: string;
+  setup: ClientSetupInfo | null;
+  isDirty: boolean;
+  isWorking: boolean;
+  onRefresh: () => void;
+};
+
+export function ClientSetupOverviewCard({
+  previewState,
+  previewMessage,
+  setup,
+  isDirty,
+  isWorking,
+  onRefresh,
+}: ClientSetupOverviewCardProps) {
+  return (
+    <Card data-slot="client-setup-overview-card">
+      <CardHeader>
+        <CardTitle>{m.client_setup_title()}</CardTitle>
+        <CardDescription>{m.client_setup_desc()}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-center gap-2">
+          {shouldShowBadge(previewState) ? (
+            <Badge variant={toBadgeVariant(previewState)}>{toBadgeLabel(previewState)}</Badge>
+          ) : null}
+          <Button type="button" variant="outline" size="sm" onClick={onRefresh} disabled={isWorking}>
+            {m.common_refresh()}
+          </Button>
+        </div>
+
+        {previewMessage ? (
+          <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+            {previewMessage}
+          </div>
+        ) : null}
+
+        {isDirty ? (
+          <div className="rounded-md border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+            {m.client_setup_dirty_notice()}
+          </div>
+        ) : null}
+
+        {setup ? (
+          <div className="rounded-md border border-border/60 bg-background/60 p-3">
+            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+              {m.client_setup_proxy_base_url_label()}
+            </p>
+            <p className="mt-1 font-mono text-xs text-foreground/80">
+              {setup.proxy_http_base_url}
+            </p>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- Split the Agents auto-setup UI into a top-level overview card plus separate Claude Code, Codex, and OpenCode cards.
- Extracted setup UI, detail renderers, and state hooks into dedicated modules to keep files small and reusable.
- Hide idle status badges so only working/success/error states are surfaced.
- Updated Agents labels to "Agents Auto Setup" in EN/ZH strings.

## Why
- Requested to make Claude/Codex/OpenCode independent cards instead of being nested inside the Proxy Base URL card, and to remove the noisy idle state indicator.

## Implementation details
- New helper modules: `client-setup-ui.tsx`, `client-setup-details.tsx`, `client-setup-state.ts`.
- `ClientSetupCard` now composes the overview card + tool cards list and keeps the plaintext token warning at the bottom.
- Badge rendering is gated by `state !== "idle"`.

## Testing
- Not run (local environment lacked `typescript` for `npx tsc --noEmit`).
