### PR TITLE
Gracefully stop proxy before updater relaunch

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -230,6 +230,16 @@ async fn proxy_stop(
 }
 
 #[tauri::command]
+async fn prepare_relaunch(
+    proxy_service: tauri::State<'_, ProxyServiceHandle>,
+    tray_state: tauri::State<'_, tray::TrayState>,
+) -> Result<(), String> {
+    // Allow the app to exit even if the window is closed during relaunch.
+    tray_state.mark_quit();
+    proxy_service.stop().await.map(|_| ())
+}
+
+#[tauri::command]
 async fn proxy_restart(
     app: tauri::AppHandle,
     proxy_service: tauri::State<'_, ProxyServiceHandle>,
@@ -353,6 +363,7 @@ pub fn run() {
             proxy_status,
             proxy_start,
             proxy_stop,
+            prepare_relaunch,
             proxy_restart,
             proxy_reload,
         ])

--- a/src/features/update/updater.tsx
+++ b/src/features/update/updater.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type DownloadEvent } from "@tauri-apps/plugin-updater";
 
@@ -209,6 +210,12 @@ export function UpdaterProvider({ children }: UpdaterProviderProps) {
   const relaunchApp = useCallback(async () => {
     setState((prev) => ({ ...prev, statusMessage: "" }));
     try {
+      // Best-effort graceful shutdown before relaunching.
+      try {
+        await invoke<void>("prepare_relaunch");
+      } catch (error) {
+        setState((prev) => ({ ...prev, statusMessage: parseError(error) }));
+      }
       await relaunch();
     } catch (error) {
       // 安装成功但重启失败时，不应把更新状态标记为失败；仅展示错误提示。


### PR DESCRIPTION
## Summary
- add a `prepare_relaunch` command to stop the proxy and allow the app to quit
- call it before `relaunch()` during update restarts and surface any stop error

## Why
Upgrade restarts could leave the old process running, keeping ports/DBs busy and occasionally freezing the UI. This ensures a best-effort graceful shutdown before relaunch.

## Implementation details
- mark the tray as `should_quit` so exit isn't blocked during relaunch
- reuse the existing proxy stop path (with its 10s timeout) and continue relaunch even if it fails

## Testing
- not run (not requested)