### PR TITLE
Fix local auth string comparison

### DIFF
--- a/src-tauri/src/proxy/http.rs
+++ b/src-tauri/src/proxy/http.rs
@@ -40,7 +40,7 @@ pub(crate) fn ensure_local_auth(
         tracing::warn!(path = %path, "missing local access key");
         return Err("Missing local access key.".to_string());
     };
-    if provided != expected {
+    if provided != expected.as_str() {
         tracing::warn!(
             path = %path,
             got = %mask_key(&provided),


### PR DESCRIPTION
## Summary\n- Fix local auth comparison between provided token and configured key.\n\n## Testing\n- Not run (reported compile error).\n