### PR TITLE
fix: support Authorization header for Anthropic local auth

### DIFF
--- a/src-tauri/src/proxy/http.rs
+++ b/src-tauri/src/proxy/http.rs
@@ -66,12 +66,15 @@ fn resolve_local_auth_token(
     path: &str,
     query: Option<&str>,
 ) -> Result<Option<String>, String> {
-    // Local auth follows request format: Anthropic -> x-api-key, Gemini -> x-goog-api-key/?key, others -> Authorization.
+    // Local auth follows request format: Anthropic -> x-api-key (or Authorization), Gemini -> x-goog-api-key/?key, others -> Authorization.
     if is_anthropic_path(path) {
         if let Some(value) = parse_raw_header(headers, X_API_KEY)? {
             return Ok(Some(value));
         }
-        return parse_raw_header(headers, X_ANTHROPIC_API_KEY);
+        if let Some(value) = parse_raw_header(headers, X_ANTHROPIC_API_KEY)? {
+            return Ok(Some(value));
+        }
+        return parse_bearer_header(headers);
     }
 
     if gemini::is_gemini_path(path) {
@@ -384,12 +387,12 @@ mod tests {
     }
 
     #[test]
-    fn local_auth_rejects_anthropic_authorization_only() {
+    fn local_auth_accepts_anthropic_authorization_only() {
         let config = config_with_local("local-key");
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer local-key"));
         let result = ensure_local_auth(&config, &headers, "/v1/messages", None);
-        assert_eq!(result, Err("Missing local access key.".to_string()));
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src-tauri/tauri.conf.dev.json
+++ b/src-tauri/tauri.conf.dev.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Token Proxy (dev)",
-  "version": "0.1.0",
+  "version": "0.1.17",
   "identifier": "com.mxyhi.token-proxy.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- 为 Anthropic 端点的本地认证增加 Authorization Bearer token 支持
- 之前仅支持 x-api-key 或 x-anthropic-api-key，现在增加 Bearer token 回退
- 更新相关测试用例以反映新行为

## Test plan
- [ ] 使用 x-api-key 进行 Anthropic 本地认证
- [ ] 使用 x-anthropic-api-key 进行 Anthropic 本地认证
- [ ] 使用 Authorization: Bearer 进行 Anthropic 本地认证
- [ ] 运行现有测试套件确保无回归