### PR TITLE
fix: enforce upstream no-data timeout (180s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,5 +112,6 @@ curl -X POST \
 ## FAQ
 - **Port already in use?** Change `port` in `config.jsonc`; remember to update your client base URL.
 - **Got 401?** If `local_api_key` is set, you must send the format-specific local key (OpenAI/Responses: `Authorization`, Anthropic: `x-api-key`, Gemini: `x-goog-api-key` or `?key=`). With local auth enabled, configure upstream keys in `upstreams[].api_key`.
+- **Got 504?** Upstream did not send response headers or the first body chunk within 180s. For streaming responses, a 180s idle timeout between chunks may also close the connection.
 - **413 Payload Too Large?** Body exceeded `max_request_body_bytes` (default 20 MiB) or the 4 MiB transform limit for format-conversion requests.
 - **Why no system proxy?** By design, `reqwest` is built with `.no_proxy()`; set per-upstream `proxy_url` if needed.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -112,5 +112,6 @@ curl -X POST \
 ## FAQ
 - **端口被占用？** 修改 `config.jsonc` 里的 `port`，并同步更新客户端 base URL
 - **返回 401？** 设置了 `local_api_key` 就必须按接口格式发送本地 key（OpenAI/Responses 用 `Authorization`；Anthropic 用 `x-api-key`；Gemini 用 `x-goog-api-key` 或 `?key=`）；开启本地鉴权后，上游密钥请配置在 `upstreams[].api_key`
+- **返回 504？** 上游在 180 秒内未返回响应头或首个 body chunk。对于流式响应，若相邻 chunk 间空闲超过 180 秒，连接也可能被关闭。
 - **413 Payload Too Large？** 请求体超过 `max_request_body_bytes`（默认 20 MiB）或格式转换场景的 4 MiB 处理上限
 - **为什么不走系统代理？** `reqwest` 默认 `no_proxy()`；如需代理，请在每个 upstream 设置 `proxy_url`

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -15,6 +15,7 @@ mod compat_reason;
 mod openai_compat;
 mod request_body;
 mod response;
+mod redact;
 mod server;
 mod server_helpers;
 mod sse;
@@ -26,7 +27,16 @@ mod usage;
 use std::{
     collections::HashMap,
     sync::{atomic::AtomicUsize, Arc},
+    time::Duration,
 };
+
+// 上游“无数据响应”超时：同时用于等待响应头（TTFB）与流式 body 的空闲超时。
+// - 生产：180s（用户要求写死）
+// - 测试：缩短，避免用例卡 180s
+#[cfg(test)]
+pub(crate) const UPSTREAM_NO_DATA_TIMEOUT: Duration = Duration::from_millis(50);
+#[cfg(not(test))]
+pub(crate) const UPSTREAM_NO_DATA_TIMEOUT: Duration = Duration::from_secs(180);
 
 struct ProxyState {
     config: config::ProxyConfig,

--- a/src-tauri/src/proxy/redact.rs
+++ b/src-tauri/src/proxy/redact.rs
@@ -1,0 +1,25 @@
+pub(crate) fn redact_query_param_value(message: &str, name: &str) -> String {
+    let needle = format!("{name}=");
+    let mut output = String::with_capacity(message.len());
+    let mut rest = message;
+
+    while let Some(pos) = rest.find(&needle) {
+        let (before, after) = rest.split_at(pos);
+        output.push_str(before);
+        output.push_str(&needle);
+        output.push_str("***");
+
+        let after = &after[needle.len()..];
+        let mut end = after.len();
+        for (idx, ch) in after.char_indices() {
+            if matches!(ch, '&' | ')' | ' ' | '\n' | '\r' | '\t' | '"' | '\'') {
+                end = idx;
+                break;
+            }
+        }
+        rest = &after[end..];
+    }
+
+    output.push_str(rest);
+    output
+}

--- a/src-tauri/src/proxy/response.rs
+++ b/src-tauri/src/proxy/response.rs
@@ -10,15 +10,16 @@ use std::{
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
+use super::{redact::redact_query_param_value, UPSTREAM_NO_DATA_TIMEOUT};
 use super::{
     gemini_compat,
     http,
     log::{build_log_entry, LogContext, LogWriter, UsageSnapshot},
-    request_detail::RequestDetailSnapshot,
     model,
     openai_compat::{transform_response_body, FormatTransform},
     token_rate::{RequestTokenTracker, TokenRateTracker},
     usage::extract_usage_from_response,
+    request_detail::RequestDetailSnapshot,
     RequestMeta,
 };
 
@@ -166,12 +167,68 @@ async fn build_stream_response(
     response_transform: FormatTransform,
     model_override: Option<&str>,
 ) -> Response {
+    let mut context = context;
+    let mut upstream = upstream_stream::with_idle_timeout(upstream_res.bytes_stream());
+    let first = upstream.next().await;
+
+    let upstream = match first {
+        Some(Ok(chunk)) => {
+            if context.ttfb_ms.is_none() {
+                context.ttfb_ms = Some(context.start.elapsed().as_millis());
+            }
+            futures_util::stream::iter(vec![Ok::<
+                Bytes,
+                upstream_stream::UpstreamStreamError<reqwest::Error>,
+            >(chunk)])
+            .chain(upstream)
+            .boxed()
+        }
+        Some(Err(err)) => {
+            let (status, message) = match err {
+                upstream_stream::UpstreamStreamError::IdleTimeout(_) => (
+                    StatusCode::GATEWAY_TIMEOUT,
+                    format!(
+                        "Upstream response timed out after {}s.",
+                        UPSTREAM_NO_DATA_TIMEOUT.as_secs()
+                    ),
+                ),
+                upstream_stream::UpstreamStreamError::Upstream(err) => {
+                    let raw = err.to_string();
+                    let message = if context.provider == PROVIDER_GEMINI {
+                        redact_query_param_value(&raw, "key")
+                    } else {
+                        raw
+                    };
+                    (
+                        StatusCode::BAD_GATEWAY,
+                        format!("Failed to read upstream response: {message}"),
+                    )
+                }
+            };
+
+            context.status = status.as_u16();
+            let empty_usage = UsageSnapshot {
+                usage: None,
+                cached_tokens: None,
+                usage_json: None,
+            };
+            let entry = build_log_entry(&context, empty_usage, Some(message.clone()));
+            log.clone().write_detached(entry);
+            return http::error_response(status, message);
+        }
+        None => {
+            // 上游无 body：避免在下游转换链路里“空跑”并丢日志，这里直接返回空体。
+            // 这个分支理论上很少出现（SSE/streaming 通常至少会输出一段数据）。
+            return http::build_response(status, headers, Body::empty());
+        }
+    };
+
     let stream = match response_transform {
         FormatTransform::None => {
             if let Some(model_override) = model_override {
                 if should_rewrite_sse_model(&context.provider) {
                     streaming::stream_with_logging_and_model_override(
-                        upstream_res.bytes_stream(),
+                        upstream,
                         context,
                         log,
                         model_override.to_string(),
@@ -180,7 +237,7 @@ async fn build_stream_response(
                     .boxed()
                 } else {
                     streaming::stream_with_logging(
-                        upstream_res.bytes_stream(),
+                        upstream,
                         context,
                         log,
                         request_tracker,
@@ -189,7 +246,7 @@ async fn build_stream_response(
                 }
             } else {
                 streaming::stream_with_logging(
-                    upstream_res.bytes_stream(),
+                    upstream,
                     context,
                     log,
                     request_tracker,
@@ -199,7 +256,7 @@ async fn build_stream_response(
         }
         FormatTransform::ResponsesToChat => {
             responses_to_chat::stream_responses_to_chat(
-                upstream_res.bytes_stream(),
+                upstream,
                 context,
                 log,
                 request_tracker,
@@ -207,12 +264,17 @@ async fn build_stream_response(
                 .boxed()
         }
         FormatTransform::ChatToResponses => {
-            stream_chat_to_responses(upstream_res.bytes_stream(), context, log, request_tracker)
+            stream_chat_to_responses(
+                upstream,
+                context,
+                log,
+                request_tracker,
+            )
                 .boxed()
         }
         FormatTransform::ResponsesToAnthropic => {
             responses_to_anthropic::stream_responses_to_anthropic(
-                upstream_res.bytes_stream(),
+                upstream,
                 context,
                 log,
                 request_tracker,
@@ -221,7 +283,7 @@ async fn build_stream_response(
         }
         FormatTransform::AnthropicToResponses => {
             anthropic_to_responses::stream_anthropic_to_responses(
-                upstream_res.bytes_stream(),
+                upstream,
                 context,
                 log,
                 request_tracker,
@@ -234,7 +296,7 @@ async fn build_stream_response(
             let intermediate_log = Arc::new(LogWriter::new(None));
             let intermediate_tracker = RequestTokenTracker::disabled();
             let responses_stream = chat_to_responses::stream_chat_to_responses(
-                upstream_res.bytes_stream(),
+                upstream,
                 context.clone(),
                 intermediate_log,
                 intermediate_tracker,
@@ -254,7 +316,7 @@ async fn build_stream_response(
             let intermediate_log = Arc::new(LogWriter::new(None));
             let intermediate_tracker = RequestTokenTracker::disabled();
             let responses_stream = anthropic_to_responses::stream_anthropic_to_responses(
-                upstream_res.bytes_stream(),
+                upstream,
                 context.clone(),
                 intermediate_log,
                 intermediate_tracker,
@@ -274,7 +336,7 @@ async fn build_stream_response(
             let first_log = Arc::new(LogWriter::new(None));
             let first_tracker = RequestTokenTracker::disabled();
             let chat_stream = gemini_compat::stream_gemini_to_chat(
-                upstream_res.bytes_stream(),
+                upstream,
                 context.clone(),
                 first_log,
                 first_tracker,
@@ -303,7 +365,7 @@ async fn build_stream_response(
             let first_log = Arc::new(LogWriter::new(None));
             let first_tracker = RequestTokenTracker::disabled();
             let responses_stream = anthropic_to_responses::stream_anthropic_to_responses(
-                upstream_res.bytes_stream(),
+                upstream,
                 context.clone(),
                 first_log,
                 first_tracker,
@@ -322,7 +384,7 @@ async fn build_stream_response(
         }
         FormatTransform::GeminiToChat => {
             gemini_compat::stream_gemini_to_chat(
-                upstream_res.bytes_stream(),
+                upstream,
                 context,
                 log,
                 request_tracker,
@@ -331,7 +393,7 @@ async fn build_stream_response(
         }
         FormatTransform::ChatToGemini => {
             gemini_compat::stream_chat_to_gemini(
-                upstream_res.bytes_stream(),
+                upstream,
                 context,
                 log,
                 request_tracker,
@@ -343,7 +405,7 @@ async fn build_stream_response(
             let intermediate_log = Arc::new(LogWriter::new(None));
             let intermediate_tracker = RequestTokenTracker::disabled();
             let chat_stream = responses_to_chat::stream_responses_to_chat(
-                upstream_res.bytes_stream(),
+                upstream,
                 context.clone(),
                 intermediate_log,
                 intermediate_tracker,
@@ -356,7 +418,7 @@ async fn build_stream_response(
             let intermediate_log = Arc::new(LogWriter::new(None));
             let intermediate_tracker = RequestTokenTracker::disabled();
             let chat_stream = gemini_compat::stream_gemini_to_chat(
-                upstream_res.bytes_stream(),
+                upstream,
                 context.clone(),
                 intermediate_log,
                 intermediate_tracker,
@@ -381,11 +443,31 @@ async fn build_buffered_response(
     model_override: Option<&str>,
 ) -> Response {
     let mut context = context;
-    let bytes = match read_upstream_bytes_with_ttfb(upstream_res, &mut context).await {
+    let bytes = match upstream_read::read_upstream_bytes_with_ttfb(upstream_res, &mut context).await {
         Ok(bytes) => bytes,
         Err(err) => {
-            let message = format!("Failed to read upstream response: {err}");
-            context.status = StatusCode::BAD_GATEWAY.as_u16();
+            let (status, message) = match err {
+                upstream_stream::UpstreamStreamError::IdleTimeout(_) => (
+                    StatusCode::GATEWAY_TIMEOUT,
+                    format!(
+                        "Upstream response timed out after {}s.",
+                        UPSTREAM_NO_DATA_TIMEOUT.as_secs()
+                    ),
+                ),
+                upstream_stream::UpstreamStreamError::Upstream(err) => {
+                    let raw = err.to_string();
+                    let message = if context.provider == PROVIDER_GEMINI {
+                        redact_query_param_value(&raw, "key")
+                    } else {
+                        raw
+                    };
+                    (
+                        StatusCode::BAD_GATEWAY,
+                        format!("Failed to read upstream response: {message}"),
+                    )
+                }
+            };
+            context.status = status.as_u16();
             let empty_usage = UsageSnapshot {
                 usage: None,
                 cached_tokens: None,
@@ -393,7 +475,7 @@ async fn build_buffered_response(
             };
             let entry = build_log_entry(&context, empty_usage, Some(message.clone()));
             log.clone().write_detached(entry);
-            return http::error_response(StatusCode::BAD_GATEWAY, message);
+            return http::error_response(status, message);
         }
     };
     let usage = extract_usage_from_response(&bytes);
@@ -421,25 +503,9 @@ async fn build_buffered_response(
     log.clone().write_detached(entry);
 
     let output = maybe_override_response_model(output, model_override);
-    apply_output_tokens_from_response(&request_tracker, &context.provider, &output).await;
+    token_count::apply_output_tokens_from_response(&request_tracker, &context.provider, &output).await;
 
     http::build_response(status, headers, Body::from(output))
-}
-
-async fn read_upstream_bytes_with_ttfb(
-    upstream_res: reqwest::Response,
-    context: &mut LogContext,
-) -> Result<Bytes, reqwest::Error> {
-    let mut stream = upstream_res.bytes_stream();
-    let mut out = Vec::new();
-    while let Some(item) = stream.next().await {
-        let chunk = item?;
-        if context.ttfb_ms.is_none() {
-            context.ttfb_ms = Some(context.start.elapsed().as_millis());
-        }
-        out.extend_from_slice(chunk.as_ref());
-    }
-    Ok(Bytes::from(out))
 }
 
 // 只对 data-only SSE 的提供商做行级重写，避免破坏带 event: 行的流。
@@ -456,15 +522,15 @@ fn maybe_override_response_model(bytes: Bytes, model_override: Option<&str>) -> 
     model::rewrite_response_model(&bytes, model_override).unwrap_or(bytes)
 }
 
-fn stream_chat_to_responses(
-    upstream: impl futures_util::stream::Stream<Item = Result<Bytes, reqwest::Error>>
-        + Unpin
-        + Send
-        + 'static,
+fn stream_chat_to_responses<E>(
+    upstream: impl futures_util::stream::Stream<Item = Result<Bytes, E>> + Unpin + Send + 'static,
     context: LogContext,
     log: Arc<LogWriter>,
     token_tracker: RequestTokenTracker,
-) -> impl futures_util::stream::Stream<Item = Result<Bytes, std::io::Error>> + Send {
+) -> impl futures_util::stream::Stream<Item = Result<Bytes, std::io::Error>> + Send
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
     chat_to_responses::stream_chat_to_responses(upstream, context, log, token_tracker)
 }
 
@@ -483,92 +549,6 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
-async fn apply_output_tokens_from_response(
-    tracker: &RequestTokenTracker,
-    provider: &str,
-    bytes: &Bytes,
-) {
-    let Ok(value) = serde_json::from_slice::<Value>(bytes) else {
-        return;
-    };
-    let mut texts = Vec::new();
-
-    match provider {
-        PROVIDER_OPENAI | PROVIDER_OPENAI_RESPONSES => {
-            if let Some(choices) = value.get("choices").and_then(Value::as_array) {
-                for choice in choices {
-                    if let Some(content) = choice.get("message").and_then(|message| message.get("content")) {
-                        if let Some(text) = content.as_str() {
-                            texts.push(text.to_string());
-                        } else if let Some(parts) = content.as_array() {
-                            for part in parts {
-                                if let Some(text) = part.get("text").and_then(Value::as_str) {
-                                    texts.push(text.to_string());
-                                }
-                            }
-                        }
-                    }
-                    if let Some(text) = choice.get("text").and_then(Value::as_str) {
-                        texts.push(text.to_string());
-                    }
-                }
-            }
-            if texts.is_empty() {
-                if let Some(output) = value.get("output").and_then(Value::as_array) {
-                    collect_responses_output(output, &mut texts);
-                }
-            }
-        }
-        PROVIDER_ANTHROPIC => {
-            if let Some(content) = value.get("content").and_then(Value::as_array) {
-                for item in content {
-                    if let Some(text) = item.get("text").and_then(Value::as_str) {
-                        texts.push(text.to_string());
-                    }
-                }
-            }
-        }
-        PROVIDER_GEMINI => {
-            if let Some(candidates) = value.get("candidates").and_then(Value::as_array) {
-                collect_gemini_output(candidates, &mut texts);
-            }
-        }
-        _ => {}
-    }
-    if texts.is_empty() {
-        return;
-    }
-    for text in texts {
-        tracker.add_output_text(&text).await;
-    }
-}
-
-fn collect_responses_output(output: &[Value], texts: &mut Vec<String>) {
-    for item in output {
-        if let Some(content) = item.get("content").and_then(Value::as_array) {
-            for part in content {
-                if let Some(text) = part.get("text").and_then(Value::as_str) {
-                    texts.push(text.to_string());
-                }
-            }
-        }
-    }
-}
-
-fn collect_gemini_output(candidates: &[Value], texts: &mut Vec<String>) {
-    for candidate in candidates {
-        if let Some(content) = candidate.get("content") {
-            if let Some(parts) = content.get("parts").and_then(Value::as_array) {
-                for part in parts {
-                    if let Some(text) = part.get("text").and_then(Value::as_str) {
-                        texts.push(text.to_string());
-                    }
-                }
-            }
-        }
-    }
-}
-
 fn response_error_text(bytes: &Bytes) -> String {
     let slice = bytes.as_ref();
     if slice.len() <= RESPONSE_ERROR_LIMIT_BYTES {
@@ -583,6 +563,9 @@ mod anthropic_to_responses;
 mod responses_to_chat;
 mod responses_to_anthropic;
 mod streaming;
+mod token_count;
+mod upstream_read;
+mod upstream_stream;
 
 #[cfg(test)]
 mod tests;

--- a/src-tauri/src/proxy/response/streaming.rs
+++ b/src-tauri/src/proxy/response/streaming.rs
@@ -12,15 +12,15 @@ use super::super::sse::SseEventParser;
 use super::super::token_rate::RequestTokenTracker;
 use super::super::usage::SseUsageCollector;
 
-pub(super) fn stream_with_logging(
-    upstream: impl futures_util::stream::Stream<Item = Result<Bytes, reqwest::Error>>
-        + Unpin
-        + Send
-        + 'static,
+pub(super) fn stream_with_logging<E>(
+    upstream: impl futures_util::stream::Stream<Item = Result<Bytes, E>> + Unpin + Send + 'static,
     context: LogContext,
     log: Arc<LogWriter>,
     token_tracker: RequestTokenTracker,
-) -> impl futures_util::stream::Stream<Item = Result<Bytes, std::io::Error>> + Send {
+) -> impl futures_util::stream::Stream<Item = Result<Bytes, std::io::Error>> + Send
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
     let collector = SseUsageCollector::new();
     let parser = SseEventParser::new();
     try_unfold(
@@ -79,16 +79,16 @@ pub(super) fn stream_with_logging(
     )
 }
 
-pub(super) fn stream_with_logging_and_model_override(
-    upstream: impl futures_util::stream::Stream<Item = Result<Bytes, reqwest::Error>>
-        + Unpin
-        + Send
-        + 'static,
+pub(super) fn stream_with_logging_and_model_override<E>(
+    upstream: impl futures_util::stream::Stream<Item = Result<Bytes, E>> + Unpin + Send + 'static,
     context: LogContext,
     log: Arc<LogWriter>,
     model_override: String,
     token_tracker: RequestTokenTracker,
-) -> impl futures_util::stream::Stream<Item = Result<Bytes, std::io::Error>> + Send {
+) -> impl futures_util::stream::Stream<Item = Result<Bytes, std::io::Error>> + Send
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
     let state = ModelOverrideStreamState::new(upstream, context, log, model_override, token_tracker);
     try_unfold(state, |state| async move { state.step().await })
 }
@@ -106,9 +106,10 @@ struct ModelOverrideStreamState<S> {
     logged: bool,
 }
 
-impl<S> ModelOverrideStreamState<S>
+impl<S, E> ModelOverrideStreamState<S>
 where
-    S: futures_util::stream::Stream<Item = Result<Bytes, reqwest::Error>> + Unpin + Send + 'static,
+    S: futures_util::stream::Stream<Item = Result<Bytes, E>> + Unpin + Send + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     fn new(
         upstream: S,

--- a/src-tauri/src/proxy/response/tests.rs
+++ b/src-tauri/src/proxy/response/tests.rs
@@ -275,7 +275,7 @@ fn stream_chat_to_responses_handles_chunk_boundaries_and_emits_created_delta_don
         let (first_a, first_b) = first_event.split_at(12);
 
         let upstream = futures_util::stream::iter(vec![
-            Ok(Bytes::from(first_a.to_string())),
+            Ok::<Bytes, reqwest::Error>(Bytes::from(first_a.to_string())),
             Ok(Bytes::from(first_b.to_string())),
             Ok(Bytes::from(
                 "data: {\"choices\":[{\"delta\":{\"content\":\"!\"}}]}\n\n",
@@ -386,7 +386,7 @@ fn stream_chat_to_responses_emits_function_call_events_and_includes_them_in_comp
     };
 
         let upstream = futures_util::stream::iter(vec![
-            Ok(Bytes::from(
+            Ok::<Bytes, reqwest::Error>(Bytes::from(
                 "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_foo\",\"type\":\"function\",\"function\":{\"name\":\"getRandomNumber\",\"arguments\":\"{\\\"a\\\":\\\"0\\\"\"}}]}}]}\n\n",
             )),
             Ok(Bytes::from(

--- a/src-tauri/src/proxy/response/token_count.rs
+++ b/src-tauri/src/proxy/response/token_count.rs
@@ -1,0 +1,96 @@
+use axum::body::Bytes;
+use serde_json::Value;
+
+use super::super::token_rate::RequestTokenTracker;
+
+pub(super) async fn apply_output_tokens_from_response(
+    tracker: &RequestTokenTracker,
+    provider: &str,
+    bytes: &Bytes,
+) {
+    let Ok(value) = serde_json::from_slice::<Value>(bytes) else {
+        return;
+    };
+    let mut texts = Vec::new();
+
+    match provider {
+        "openai" | "openai-response" => {
+            if let Some(choices) = value.get("choices").and_then(Value::as_array) {
+                for choice in choices {
+                    if let Some(content) = choice
+                        .get("message")
+                        .and_then(|message| message.get("content"))
+                    {
+                        if let Some(text) = content.as_str() {
+                            texts.push(text.to_string());
+                        } else if let Some(parts) = content.as_array() {
+                            for part in parts {
+                                if let Some(text) = part.get("text").and_then(Value::as_str) {
+                                    texts.push(text.to_string());
+                                }
+                            }
+                        }
+                    }
+                    if let Some(text) = choice.get("text").and_then(Value::as_str) {
+                        texts.push(text.to_string());
+                    }
+                }
+            }
+            if texts.is_empty() {
+                if let Some(output) = value.get("output").and_then(Value::as_array) {
+                    collect_responses_output(output, &mut texts);
+                }
+            }
+        }
+        "anthropic" => {
+            if let Some(content) = value.get("content").and_then(Value::as_array) {
+                for item in content {
+                    if let Some(text) = item.get("text").and_then(Value::as_str) {
+                        texts.push(text.to_string());
+                    }
+                }
+            }
+        }
+        "gemini" => {
+            if let Some(candidates) = value.get("candidates").and_then(Value::as_array) {
+                collect_gemini_output(candidates, &mut texts);
+            }
+        }
+        _ => {}
+    }
+
+    if texts.is_empty() {
+        return;
+    }
+
+    for text in texts {
+        tracker.add_output_text(&text).await;
+    }
+}
+
+fn collect_responses_output(output: &[Value], texts: &mut Vec<String>) {
+    for item in output {
+        if let Some(content) = item.get("content").and_then(Value::as_array) {
+            for part in content {
+                if let Some(text) = part.get("text").and_then(Value::as_str) {
+                    texts.push(text.to_string());
+                }
+            }
+        }
+    }
+}
+
+fn collect_gemini_output(candidates: &[Value], texts: &mut Vec<String>) {
+    for candidate in candidates {
+        if let Some(content) = candidate.get("content") {
+            if let Some(parts) = content.get("parts").and_then(Value::as_array) {
+                for part in parts {
+                    if let Some(text) = part.get("text").and_then(Value::as_str) {
+                        texts.push(text.to_string());
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src-tauri/src/proxy/response/upstream_read.rs
+++ b/src-tauri/src/proxy/response/upstream_read.rs
@@ -1,0 +1,23 @@
+use axum::body::Bytes;
+use futures_util::StreamExt;
+
+use super::upstream_stream::{self, UpstreamStreamError};
+use super::super::log::LogContext;
+
+pub(super) async fn read_upstream_bytes_with_ttfb(
+    upstream_res: reqwest::Response,
+    context: &mut LogContext,
+) -> Result<Bytes, UpstreamStreamError<reqwest::Error>> {
+    let mut upstream = upstream_stream::with_idle_timeout(upstream_res.bytes_stream());
+    let mut out = Vec::new();
+
+    while let Some(item) = upstream.next().await {
+        let chunk = item?;
+        if context.ttfb_ms.is_none() {
+            context.ttfb_ms = Some(context.start.elapsed().as_millis());
+        }
+        out.extend_from_slice(chunk.as_ref());
+    }
+
+    Ok(Bytes::from(out))
+}

--- a/src-tauri/src/proxy/response/upstream_stream.rs
+++ b/src-tauri/src/proxy/response/upstream_stream.rs
@@ -1,0 +1,97 @@
+use axum::body::Bytes;
+use futures_util::{stream::try_unfold, StreamExt};
+use std::{error::Error, fmt, time::Duration};
+
+use crate::proxy::UPSTREAM_NO_DATA_TIMEOUT;
+
+#[derive(Debug)]
+pub(crate) enum UpstreamStreamError<E> {
+    IdleTimeout(Duration),
+    Upstream(E),
+}
+
+impl<E: fmt::Display> fmt::Display for UpstreamStreamError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IdleTimeout(duration) => {
+                write!(f, "Upstream stream idle timeout after {}s.", duration.as_secs())
+            }
+            Self::Upstream(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl<E: Error + 'static> Error for UpstreamStreamError<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::IdleTimeout(_) => None,
+            Self::Upstream(err) => Some(err),
+        }
+    }
+}
+
+pub(super) fn with_idle_timeout<E>(
+    upstream: impl futures_util::stream::Stream<Item = Result<Bytes, E>> + Unpin + Send + 'static,
+) -> futures_util::stream::BoxStream<'static, Result<Bytes, UpstreamStreamError<E>>>
+where
+    E: Error + Send + Sync + 'static,
+{
+    try_unfold(upstream, |mut upstream| async move {
+        match tokio::time::timeout(UPSTREAM_NO_DATA_TIMEOUT, upstream.next()).await {
+            Ok(Some(Ok(chunk))) => Ok(Some((chunk, upstream))),
+            Ok(Some(Err(err))) => Err(UpstreamStreamError::Upstream(err)),
+            Ok(None) => Ok(None),
+            Err(_) => Err(UpstreamStreamError::IdleTimeout(UPSTREAM_NO_DATA_TIMEOUT)),
+        }
+    })
+    .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt;
+
+    #[tokio::test]
+    async fn idle_timeout_returns_error() {
+        let upstream = futures_util::stream::pending::<Result<Bytes, std::io::Error>>();
+        let mut stream = with_idle_timeout(upstream);
+
+        let item = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("test timeout")
+            .expect("item")
+            .expect_err("timeout error");
+
+        assert!(matches!(item, UpstreamStreamError::IdleTimeout(_)));
+    }
+
+    #[tokio::test]
+    async fn passes_through_success_chunks() {
+        let upstream = futures_util::stream::iter(vec![Ok::<Bytes, std::io::Error>(
+            Bytes::from_static(b"hello"),
+        )]);
+        let mut stream = with_idle_timeout(upstream);
+
+        let first = stream.next().await.expect("first").expect("ok");
+        assert_eq!(first, Bytes::from_static(b"hello"));
+
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn propagates_upstream_errors() {
+        let upstream = futures_util::stream::iter(vec![Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "boom",
+        ))]);
+        let mut stream = with_idle_timeout(upstream);
+
+        let err = stream
+            .next()
+            .await
+            .expect("first")
+            .expect_err("err");
+        assert!(matches!(err, UpstreamStreamError::Upstream(_)));
+    }
+}

--- a/src-tauri/src/proxy/upstream.rs
+++ b/src-tauri/src/proxy/upstream.rs
@@ -1,6 +1,5 @@
 use axum::{
     http::{
-        header::{HeaderName, HeaderValue, CONTENT_LENGTH, HOST},
         HeaderMap, Method, StatusCode,
     },
     response::Response,
@@ -11,22 +10,21 @@ use std::{
     },
     time::Instant,
 };
+use tokio::time::timeout;
 
-const ANTHROPIC_VERSION_HEADER: &str = "anthropic-version";
-const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
 const GEMINI_API_KEY_QUERY: &str = "key";
-const GEMINI_API_KEY_HEADER: HeaderName = HeaderName::from_static("x-goog-api-key");
 const LOCAL_UPSTREAM_ID: &str = "local";
 
+mod request;
 mod utils;
 
 use utils::{
-    build_group_order, ensure_query_param, extract_query_param, is_retryable_error,
-    is_retryable_status, resolve_group_start, sanitize_upstream_error,
+    build_group_order, is_retryable_error, is_retryable_status, resolve_group_start,
+    sanitize_upstream_error,
 };
 
 #[cfg(test)]
-use utils::redact_query_param_value;
+use crate::proxy::redact::redact_query_param_value;
 
 use super::{
     config::UpstreamRuntime,
@@ -34,11 +32,11 @@ use super::{
     http,
     http::RequestAuth,
     log::{build_log_entry, LogContext, LogWriter, UsageSnapshot},
-    model,
     openai_compat::FormatTransform,
     request_detail::RequestDetailSnapshot,
     request_body::ReplayableBody,
     response::{build_proxy_response, build_proxy_response_buffered},
+    UPSTREAM_NO_DATA_TIMEOUT,
     ProxyState,
     RequestMeta,
 };
@@ -60,6 +58,7 @@ pub(super) async fn forward_upstream_request(
 ) -> Response {
     let mut last_retry_error: Option<String> = None;
     let mut last_retry_response: Option<Response> = None;
+    let mut last_timeout_error: Option<String> = None;
     let mut attempted = 0;
     let mut missing_auth = false;
 
@@ -110,6 +109,9 @@ pub(super) async fn forward_upstream_request(
         if let Some(response) = result.last_retry_response {
             last_retry_response = Some(response);
         }
+        if result.last_timeout_error.is_some() {
+            last_timeout_error = result.last_timeout_error;
+        }
         if result.last_retry_error.is_some() {
             last_retry_error = result.last_retry_error;
         }
@@ -132,6 +134,9 @@ pub(super) async fn forward_upstream_request(
     if let Some(response) = last_retry_response {
         return response;
     }
+    if let Some(err) = last_timeout_error {
+        return http::error_response(StatusCode::GATEWAY_TIMEOUT, err);
+    }
     if let Some(err) = last_retry_error {
         return http::error_response(StatusCode::BAD_GATEWAY, format!("Upstream request failed: {err}"));
     }
@@ -142,6 +147,7 @@ struct GroupAttemptResult {
     response: Option<Response>,
     attempted: usize,
     missing_auth: bool,
+    last_timeout_error: Option<String>,
     last_retry_error: Option<String>,
     last_retry_response: Option<Response>,
 }
@@ -151,6 +157,7 @@ enum AttemptOutcome {
     Retryable {
         message: String,
         response: Option<Response>,
+        is_timeout: bool,
     },
     Fatal(Response),
     SkippedAuth,
@@ -178,6 +185,7 @@ async fn try_group_upstreams(
     response_transform: FormatTransform,
     request_detail: Option<RequestDetailSnapshot>,
 ) -> GroupAttemptResult {
+    let mut last_timeout_error = None;
     let mut last_retry_error = None;
     let mut last_retry_response = None;
     let mut attempted = 0;
@@ -209,12 +217,17 @@ async fn try_group_upstreams(
                     response: Some(response),
                     attempted,
                     missing_auth,
+                    last_timeout_error,
                     last_retry_error,
                     last_retry_response,
                 };
             }
-            AttemptOutcome::Retryable { message, response } => {
-                last_retry_error = Some(message);
+            AttemptOutcome::Retryable { message, response, is_timeout } => {
+                if is_timeout {
+                    last_timeout_error = Some(message.clone());
+                } else {
+                    last_retry_error = Some(message.clone());
+                }
                 if response.is_some() {
                     last_retry_response = response;
                 }
@@ -228,6 +241,7 @@ async fn try_group_upstreams(
         response: None,
         attempted,
         missing_auth,
+        last_timeout_error,
         last_retry_error,
         last_retry_response,
     }
@@ -271,12 +285,40 @@ async fn attempt_upstream(
             return AttemptOutcome::Fatal(http::error_response(StatusCode::BAD_GATEWAY, message))
         }
     };
-    let upstream_res = client
-        .request(method, prepared.upstream_url)
-        .headers(prepared.request_headers)
-        .body(prepared.upstream_body)
-        .send()
-        .await;
+    let upstream_res = timeout(
+        UPSTREAM_NO_DATA_TIMEOUT,
+        client
+            .request(method, prepared.upstream_url)
+            .headers(prepared.request_headers)
+            .body(prepared.upstream_body)
+            .send(),
+    )
+    .await;
+    let upstream_res = match upstream_res {
+        Ok(result) => result,
+        Err(_) => {
+            let message = format!(
+                "Upstream did not respond within {}s.",
+                UPSTREAM_NO_DATA_TIMEOUT.as_secs()
+            );
+            log_upstream_error_if_needed(
+                &state.log,
+                request_detail.as_ref(),
+                meta,
+                provider,
+                &upstream.id,
+                inbound_path,
+                StatusCode::GATEWAY_TIMEOUT,
+                message.clone(),
+                start_time,
+            );
+            return AttemptOutcome::Retryable {
+                message,
+                response: None,
+                is_timeout: true,
+            };
+        }
+    };
     handle_upstream_result(
         upstream_res,
         &prepared.meta,
@@ -312,14 +354,14 @@ async fn prepare_upstream_request(
         &upstream_path_with_query,
         &upstream_url,
     )?;
-    let request_headers = build_request_headers(
+    let request_headers = request::build_request_headers(
         provider,
         headers,
         auth,
         upstream.header_overrides.as_deref(),
     );
     let upstream_body =
-        build_upstream_body(provider, &upstream_path_with_query, body, &mapped_meta).await?;
+        request::build_upstream_body(provider, &upstream_path_with_query, body, &mapped_meta).await?;
     Ok(PreparedUpstreamRequest {
         upstream_url,
         request_headers,
@@ -336,7 +378,12 @@ fn resolve_upstream_auth(
     upstream_url: &str,
 ) -> Result<(String, http::UpstreamAuthHeader), AttemptOutcome> {
     if provider == "gemini" {
-        return resolve_gemini_upstream(upstream, request_auth, upstream_path_with_query, upstream_url);
+        return request::resolve_gemini_upstream(
+            upstream,
+            request_auth,
+            upstream_path_with_query,
+            upstream_url,
+        );
     }
     let auth = match http::resolve_upstream_auth(provider, upstream, request_auth) {
         Ok(Some(auth)) => auth,
@@ -376,6 +423,7 @@ async fn handle_upstream_result(
             AttemptOutcome::Retryable {
                 message: format!("Upstream responded with {}", response.status()),
                 response: Some(response),
+                is_timeout: false,
             }
         }
         Ok(res) => {
@@ -396,6 +444,11 @@ async fn handle_upstream_result(
         }
         Err(err) if is_retryable_error(&err) => {
             let message = sanitize_upstream_error(provider, &err);
+            let status = if err.is_timeout() {
+                StatusCode::GATEWAY_TIMEOUT
+            } else {
+                StatusCode::BAD_GATEWAY
+            };
             log_upstream_error_if_needed(
                 &log,
                 request_detail.as_ref(),
@@ -403,13 +456,14 @@ async fn handle_upstream_result(
                 provider,
                 upstream_id,
                 inbound_path,
-                StatusCode::BAD_GATEWAY,
+                status,
                 message.clone(),
                 start_time,
             );
             AttemptOutcome::Retryable {
                 message,
                 response: None,
+                is_timeout: err.is_timeout(),
             }
         }
         Err(err) => {
@@ -517,173 +571,13 @@ fn resolve_upstream_path_with_query(
     let Some(mapped_model) = meta.mapped_model.as_deref() else {
         return upstream_path_with_query.to_string();
     };
-    let (path, query) = split_path_query(upstream_path_with_query);
+    let (path, query) = request::split_path_query(upstream_path_with_query);
     let replaced = gemini::replace_gemini_model_in_path(path, mapped_model)
         .unwrap_or_else(|| path.to_string());
     match query {
         Some(query) => format!("{replaced}?{query}"),
         None => replaced,
     }
-}
-
-fn apply_header_overrides(
-    request_headers: &mut HeaderMap,
-    overrides: &[super::config::HeaderOverride],
-) {
-    for override_item in overrides {
-        // 屏蔽 hop-by-hop / Host / Content-Length，无论配置为何。
-        if crate::proxy::http::is_hop_header(&override_item.name)
-            || override_item.name == HOST
-            || override_item.name == CONTENT_LENGTH
-        {
-            continue;
-        }
-
-        match &override_item.value {
-            Some(value) => {
-                request_headers.insert(override_item.name.clone(), value.clone());
-            }
-            None => {
-                request_headers.remove(&override_item.name);
-            }
-        }
-    }
-}
-
-fn split_path_query(path_with_query: &str) -> (&str, Option<&str>) {
-    match path_with_query.split_once('?') {
-        Some((path, query)) => (path, Some(query)),
-        None => (path_with_query, None),
-    }
-}
-
-fn build_request_headers(
-    provider: &str,
-    headers: &HeaderMap,
-    auth: http::UpstreamAuthHeader,
-    header_overrides: Option<&[super::config::HeaderOverride]>,
-) -> HeaderMap {
-    let mut request_headers = http::build_upstream_headers(headers, auth);
-    if provider == "anthropic" && !request_headers.contains_key(ANTHROPIC_VERSION_HEADER) {
-        // Anthropic 官方 API 需要 `anthropic-version`；缺省时补一个稳定默认值，允许客户端覆盖。
-        request_headers.insert(
-            ANTHROPIC_VERSION_HEADER,
-            HeaderValue::from_static(DEFAULT_ANTHROPIC_VERSION),
-        );
-    }
-
-    if let Some(overrides) = header_overrides {
-        apply_header_overrides(&mut request_headers, overrides);
-    }
-    request_headers
-}
-
-async fn build_upstream_body(
-    provider: &str,
-    upstream_path_with_query: &str,
-    body: &ReplayableBody,
-    meta: &RequestMeta,
-) -> Result<reqwest::Body, AttemptOutcome> {
-    let mapped_body = maybe_rewrite_request_body_model(body, meta).await?;
-    let mapped_source = mapped_body.as_ref().unwrap_or(body);
-    let upstream_path = split_path_query(upstream_path_with_query).0;
-    let reasoning_body = match super::server_helpers::maybe_rewrite_openai_reasoning_effort_from_model_suffix(
-        provider,
-        upstream_path,
-        meta,
-        mapped_source,
-    )
-    .await
-    {
-        Ok(body) => body,
-        Err(err) => {
-            return Err(AttemptOutcome::Fatal(http::error_response(err.status, err.message)))
-        }
-    };
-    let source = reasoning_body
-        .as_ref()
-        .or(mapped_body.as_ref())
-        .unwrap_or(body);
-    source
-        .to_reqwest_body()
-        .await
-        .map_err(|err| {
-            AttemptOutcome::Fatal(http::error_response(
-                StatusCode::BAD_GATEWAY,
-                format!("Failed to read cached request body: {err}"),
-            ))
-        })
-}
-
-async fn maybe_rewrite_request_body_model(
-    body: &ReplayableBody,
-    meta: &RequestMeta,
-) -> Result<Option<ReplayableBody>, AttemptOutcome> {
-    if meta.model_override().is_none() {
-        return Ok(None);
-    }
-    let Some(mapped_model) = meta.mapped_model.as_deref() else {
-        return Ok(None);
-    };
-    let Some(bytes) = body
-        .read_bytes_if_small(REQUEST_MODEL_MAPPING_LIMIT_BYTES)
-        .await
-        .map_err(|err| {
-            AttemptOutcome::Fatal(http::error_response(
-                StatusCode::BAD_GATEWAY,
-                format!("Failed to read request body: {err}"),
-            ))
-        })?
-    else {
-        return Ok(None);
-    };
-    let Some(rewritten) = model::rewrite_request_model(&bytes, mapped_model) else {
-        return Ok(None);
-    };
-    Ok(Some(ReplayableBody::from_bytes(rewritten)))
-}
-
-fn resolve_gemini_upstream(
-    upstream: &UpstreamRuntime,
-    request_auth: &RequestAuth,
-    upstream_path_with_query: &str,
-    upstream_url: &str,
-) -> Result<(String, http::UpstreamAuthHeader), AttemptOutcome> {
-    let query_key = extract_query_param(upstream_path_with_query, GEMINI_API_KEY_QUERY);
-    let selected = upstream
-        .api_key
-        .as_deref()
-        .or_else(|| request_auth.gemini_api_key.as_deref())
-        .or_else(|| query_key.as_deref());
-
-    let Some(api_key) = selected else {
-        return Err(AttemptOutcome::SkippedAuth);
-    };
-
-    let upstream_url = match ensure_query_param(upstream_url, GEMINI_API_KEY_QUERY, api_key) {
-        Ok(url) => url,
-        Err(message) => {
-            return Err(AttemptOutcome::Fatal(http::error_response(
-                StatusCode::BAD_GATEWAY,
-                format!("Failed to build upstream URL: {message}"),
-            )))
-        }
-    };
-
-    let value = HeaderValue::from_str(api_key).map_err(|_| {
-        AttemptOutcome::Fatal(http::error_response(
-            StatusCode::UNAUTHORIZED,
-            "Upstream API key contains invalid characters.",
-        ))
-    })?;
-
-    Ok((
-        upstream_url,
-        http::UpstreamAuthHeader {
-            name: GEMINI_API_KEY_HEADER.clone(),
-            value,
-        },
-    ))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/proxy/upstream/request.rs
+++ b/src-tauri/src/proxy/upstream/request.rs
@@ -1,0 +1,179 @@
+use axum::http::{
+    header::{HeaderName, HeaderValue, CONTENT_LENGTH, HOST},
+    HeaderMap, StatusCode,
+};
+
+use super::{
+    utils::{ensure_query_param, extract_query_param},
+    AttemptOutcome,
+};
+use super::super::{
+    config::{HeaderOverride, UpstreamRuntime},
+    http,
+    model,
+    request_body::ReplayableBody,
+    RequestMeta,
+};
+use super::super::http::RequestAuth;
+
+const ANTHROPIC_VERSION_HEADER: &str = "anthropic-version";
+const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
+const GEMINI_API_KEY_QUERY: &str = "key";
+const GEMINI_API_KEY_HEADER: HeaderName = HeaderName::from_static("x-goog-api-key");
+
+pub(super) fn split_path_query(path_with_query: &str) -> (&str, Option<&str>) {
+    match path_with_query.split_once('?') {
+        Some((path, query)) => (path, Some(query)),
+        None => (path_with_query, None),
+    }
+}
+
+pub(super) fn build_request_headers(
+    provider: &str,
+    headers: &HeaderMap,
+    auth: http::UpstreamAuthHeader,
+    header_overrides: Option<&[HeaderOverride]>,
+) -> HeaderMap {
+    let mut request_headers = http::build_upstream_headers(headers, auth);
+    if provider == "anthropic" && !request_headers.contains_key(ANTHROPIC_VERSION_HEADER) {
+        // Anthropic 官方 API 需要 `anthropic-version`；缺省时补一个稳定默认值，允许客户端覆盖。
+        request_headers.insert(
+            ANTHROPIC_VERSION_HEADER,
+            HeaderValue::from_static(DEFAULT_ANTHROPIC_VERSION),
+        );
+    }
+
+    if let Some(overrides) = header_overrides {
+        apply_header_overrides(&mut request_headers, overrides);
+    }
+    request_headers
+}
+
+pub(super) fn apply_header_overrides(request_headers: &mut HeaderMap, overrides: &[HeaderOverride]) {
+    for override_item in overrides {
+        // 屏蔽 hop-by-hop / Host / Content-Length，无论配置为何。
+        if crate::proxy::http::is_hop_header(&override_item.name)
+            || override_item.name == HOST
+            || override_item.name == CONTENT_LENGTH
+        {
+            continue;
+        }
+
+        match &override_item.value {
+            Some(value) => {
+                request_headers.insert(override_item.name.clone(), value.clone());
+            }
+            None => {
+                request_headers.remove(&override_item.name);
+            }
+        }
+    }
+}
+
+pub(super) async fn build_upstream_body(
+    provider: &str,
+    upstream_path_with_query: &str,
+    body: &ReplayableBody,
+    meta: &RequestMeta,
+) -> Result<reqwest::Body, AttemptOutcome> {
+    let mapped_body = maybe_rewrite_request_body_model(body, meta).await?;
+    let mapped_source = mapped_body.as_ref().unwrap_or(body);
+    let upstream_path = split_path_query(upstream_path_with_query).0;
+    let reasoning_body = match super::super::server_helpers::maybe_rewrite_openai_reasoning_effort_from_model_suffix(
+        provider,
+        upstream_path,
+        meta,
+        mapped_source,
+    )
+    .await
+    {
+        Ok(body) => body,
+        Err(err) => {
+            return Err(AttemptOutcome::Fatal(http::error_response(err.status, err.message)))
+        }
+    };
+    let source = reasoning_body
+        .as_ref()
+        .or(mapped_body.as_ref())
+        .unwrap_or(body);
+    source
+        .to_reqwest_body()
+        .await
+        .map_err(|err| {
+            AttemptOutcome::Fatal(http::error_response(
+                StatusCode::BAD_GATEWAY,
+                format!("Failed to read cached request body: {err}"),
+            ))
+        })
+}
+
+async fn maybe_rewrite_request_body_model(
+    body: &ReplayableBody,
+    meta: &RequestMeta,
+) -> Result<Option<ReplayableBody>, AttemptOutcome> {
+    if meta.model_override().is_none() {
+        return Ok(None);
+    }
+    let Some(mapped_model) = meta.mapped_model.as_deref() else {
+        return Ok(None);
+    };
+    let Some(bytes) = body
+        .read_bytes_if_small(super::REQUEST_MODEL_MAPPING_LIMIT_BYTES)
+        .await
+        .map_err(|err| {
+            AttemptOutcome::Fatal(http::error_response(
+                StatusCode::BAD_GATEWAY,
+                format!("Failed to read request body: {err}"),
+            ))
+        })?
+    else {
+        return Ok(None);
+    };
+    let Some(rewritten) = model::rewrite_request_model(&bytes, mapped_model) else {
+        return Ok(None);
+    };
+    Ok(Some(ReplayableBody::from_bytes(rewritten)))
+}
+
+pub(super) fn resolve_gemini_upstream(
+    upstream: &UpstreamRuntime,
+    request_auth: &RequestAuth,
+    upstream_path_with_query: &str,
+    upstream_url: &str,
+) -> Result<(String, http::UpstreamAuthHeader), AttemptOutcome> {
+    let query_key = extract_query_param(upstream_path_with_query, GEMINI_API_KEY_QUERY);
+    let selected = upstream
+        .api_key
+        .as_deref()
+        .or_else(|| request_auth.gemini_api_key.as_deref())
+        .or_else(|| query_key.as_deref());
+
+    let Some(api_key) = selected else {
+        return Err(AttemptOutcome::SkippedAuth);
+    };
+
+    let upstream_url = match ensure_query_param(upstream_url, GEMINI_API_KEY_QUERY, api_key) {
+        Ok(url) => url,
+        Err(message) => {
+            return Err(AttemptOutcome::Fatal(http::error_response(
+                StatusCode::BAD_GATEWAY,
+                format!("Failed to build upstream URL: {message}"),
+            )))
+        }
+    };
+
+    let value = HeaderValue::from_str(api_key).map_err(|_| {
+        AttemptOutcome::Fatal(http::error_response(
+            StatusCode::UNAUTHORIZED,
+            "Upstream API key contains invalid characters.",
+        ))
+    })?;
+
+    Ok((
+        upstream_url,
+        http::UpstreamAuthHeader {
+            name: GEMINI_API_KEY_HEADER,
+            value,
+        },
+    ))
+}

--- a/src-tauri/src/proxy/upstream/tests.rs
+++ b/src-tauri/src/proxy/upstream/tests.rs
@@ -17,14 +17,14 @@ fn retryable_status_matches_new_api_policy() {
 
 #[test]
 fn extract_query_param_reads_key_value() {
-    let value = extract_query_param("/v1beta/models/x:generateContent?key=abc&foo=bar", "key");
+    let value = utils::extract_query_param("/v1beta/models/x:generateContent?key=abc&foo=bar", "key");
     assert_eq!(value.as_deref(), Some("abc"));
 }
 
 #[test]
 fn ensure_query_param_overrides_existing_value() {
     let url = "https://example.com/v1beta/models/x:generateContent?foo=bar&key=old";
-    let updated = ensure_query_param(url, "key", "new").expect("updated url");
+    let updated = utils::ensure_query_param(url, "key", "new").expect("updated url");
     assert!(updated.contains("foo=bar"));
     assert!(updated.contains("key=new"));
     assert!(!updated.contains("key=old"));
@@ -72,7 +72,7 @@ fn apply_header_overrides_sets_and_removes() {
         },
     ];
 
-    apply_header_overrides(&mut headers, &overrides);
+    request::apply_header_overrides(&mut headers, &overrides);
 
     assert_eq!(
         headers.get("x-custom").and_then(|v| v.to_str().ok()),

--- a/src-tauri/src/proxy/upstream/utils.rs
+++ b/src-tauri/src/proxy/upstream/utils.rs
@@ -2,6 +2,7 @@ use axum::http::StatusCode;
 use std::sync::atomic::Ordering;
 
 use super::super::{config::UpstreamStrategy, ProxyState};
+use crate::proxy::redact::redact_query_param_value;
 
 pub(super) fn extract_query_param(path_with_query: &str, name: &str) -> Option<String> {
     let url = url::Url::parse(&format!("http://localhost{path_with_query}")).ok()?;
@@ -38,32 +39,6 @@ pub(super) fn sanitize_upstream_error(provider: &str, err: &reqwest::Error) -> S
         return redact_query_param_value(&message, super::GEMINI_API_KEY_QUERY);
     }
     message
-}
-
-pub(super) fn redact_query_param_value(message: &str, name: &str) -> String {
-    let needle = format!("{name}=");
-    let mut output = String::with_capacity(message.len());
-    let mut rest = message;
-
-    while let Some(pos) = rest.find(&needle) {
-        let (before, after) = rest.split_at(pos);
-        output.push_str(before);
-        output.push_str(&needle);
-        output.push_str("***");
-
-        let after = &after[needle.len()..];
-        let mut end = after.len();
-        for (idx, ch) in after.char_indices() {
-            if matches!(ch, '&' | ')' | ' ' | '\n' | '\r' | '\t' | '"' | '\'') {
-                end = idx;
-                break;
-            }
-        }
-        rest = &after[end..];
-    }
-
-    output.push_str(rest);
-    output
 }
 
 pub(super) fn resolve_group_start(


### PR DESCRIPTION
## What\n- Enforce a fixed 180s upstream "no data" timeout (response headers + first body chunk) and return 504.\n- Add a 180s streaming idle timeout between chunks (may close long-idle SSE connections).\n- Log timeout errors; keep Gemini key redacted.\n\n## Notes\n- Streaming: once the first chunk is sent to the client, later idle timeouts can only terminate the stream (cannot return 504).\n- Tests use a shorter timeout to keep unit tests fast.