### PR TITLE
Align Codex Responses params with CLIProxyAPIPlus

### DIFF
--- a/src-tauri/src/proxy/codex_compat/request.rs
+++ b/src-tauri/src/proxy/codex_compat/request.rs
@@ -150,11 +150,15 @@ fn collect_function_tool_names(value: &Value) -> Vec<String> {
         if tool.get("type").and_then(Value::as_str) != Some("function") {
             continue;
         }
-        let Some(function) = tool.get("function") else {
-            continue;
-        };
-        if let Some(name) = function.get("name").and_then(Value::as_str) {
-            names.push(name.to_string());
+        let name = tool
+            .get("function")
+            .and_then(|value| value.get("name"))
+            .and_then(Value::as_str)
+            .or_else(|| tool.get("name").and_then(Value::as_str));
+        if let Some(name) = name {
+            if !name.is_empty() {
+                names.push(name.to_string());
+            }
         }
     }
     names
@@ -280,20 +284,24 @@ fn map_tools(tools: &Value, tool_map: &ToolNameMap) -> Value {
             continue;
         }
         let function = tool.get("function").unwrap_or(&Value::Null);
+        let mut item = Map::new();
+        item.insert("type".to_string(), Value::String("function".to_string()));
         let name = function
             .get("name")
             .and_then(Value::as_str)
-            .unwrap_or_default();
-        let mut item = Map::new();
-        item.insert("type".to_string(), Value::String("function".to_string()));
-        item.insert("name".to_string(), Value::String(tool_map.shorten(name)));
-        if let Some(desc) = function.get("description") {
+            .or_else(|| tool.get("name").and_then(Value::as_str));
+        if let Some(name) = name {
+            if !name.is_empty() {
+                item.insert("name".to_string(), Value::String(tool_map.shorten(name)));
+            }
+        }
+        if let Some(desc) = function.get("description").or_else(|| tool.get("description")) {
             item.insert("description".to_string(), desc.clone());
         }
-        if let Some(params) = function.get("parameters") {
+        if let Some(params) = function.get("parameters").or_else(|| tool.get("parameters")) {
             item.insert("parameters".to_string(), params.clone());
         }
-        if let Some(strict) = function.get("strict") {
+        if let Some(strict) = function.get("strict").or_else(|| tool.get("strict")) {
             item.insert("strict".to_string(), strict.clone());
         }
         output.push(Value::Object(item));
@@ -318,8 +326,15 @@ fn map_tool_choice(choice: &Value, tool_map: &ToolNameMap) -> Value {
         .get("function")
         .and_then(|value| value.get("name"))
         .and_then(Value::as_str)
-        .unwrap_or_default();
-    json!({ "type": "function", "name": tool_map.shorten(name) })
+        .or_else(|| object.get("name").and_then(Value::as_str));
+    let mut output = Map::new();
+    output.insert("type".to_string(), Value::String("function".to_string()));
+    if let Some(name) = name {
+        if !name.is_empty() {
+            output.insert("name".to_string(), Value::String(tool_map.shorten(name)));
+        }
+    }
+    Value::Object(output)
 }
 
 fn apply_text_format(response_format: Option<&Value>, text: Option<&Value>, output: &mut Map<String, Value>) {
@@ -381,6 +396,9 @@ fn normalize_responses_payload(object: &mut Map<String, Value>, model_hint: Opti
         "temperature",
         "top_p",
         "service_tier",
+        "previous_response_id",
+        "prompt_cache_retention",
+        "safety_identifier",
     ] {
         object.remove(key);
     }

--- a/src-tauri/src/proxy/codex_compat/tests.rs
+++ b/src-tauri/src/proxy/codex_compat/tests.rs
@@ -1,7 +1,7 @@
 use axum::body::Bytes;
 use serde_json::json;
 
-use super::{chat_request_to_codex, codex_response_to_chat};
+use super::{chat_request_to_codex, codex_response_to_chat, responses_request_to_codex};
 use super::tool_names::shorten_name_if_needed;
 
 #[test]
@@ -55,4 +55,68 @@ fn codex_response_to_chat_restores_tool_name() {
         .as_str()
         .expect("tool name");
     assert_eq!(name, original);
+}
+
+#[test]
+fn chat_request_to_codex_skips_missing_tool_names() {
+    let input = json!({
+        "model": "gpt-5",
+        "messages": [
+            { "role": "user", "content": "hi" }
+        ],
+        "tools": [
+            { "type": "function", "function": { "description": "noop", "parameters": {} } }
+        ],
+        "tool_choice": { "type": "function", "function": {} }
+    });
+    let bytes = Bytes::from(input.to_string());
+    let output = chat_request_to_codex(&bytes, Some("gpt-5-codex")).expect("convert");
+    let value: serde_json::Value = serde_json::from_slice(&output).expect("json");
+    let tools = value["tools"].as_array().expect("tools array");
+    assert_eq!(tools.len(), 1);
+    assert!(tools[0].get("name").is_none());
+    let tool_choice = value["tool_choice"].as_object().expect("tool_choice");
+    assert_eq!(tool_choice.get("type").and_then(serde_json::Value::as_str), Some("function"));
+    assert!(tool_choice.get("name").is_none());
+}
+
+#[test]
+fn responses_request_to_codex_uses_top_level_tool_name() {
+    let input = json!({
+        "model": "gpt-5",
+        "input": "hi",
+        "tools": [
+            { "type": "function", "name": "demo_tool", "description": "noop", "parameters": {} }
+        ],
+        "tool_choice": { "type": "function", "name": "demo_tool" }
+    });
+    let bytes = Bytes::from(input.to_string());
+    let output = responses_request_to_codex(&bytes, Some("gpt-5-codex")).expect("convert");
+    let value: serde_json::Value = serde_json::from_slice(&output).expect("json");
+    let tools = value["tools"].as_array().expect("tools array");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0]["name"], "demo_tool");
+    assert_eq!(tools[0]["description"], "noop");
+    assert!(tools[0]["parameters"].is_object());
+    assert_eq!(
+        value["tool_choice"].get("name").and_then(serde_json::Value::as_str),
+        Some("demo_tool")
+    );
+}
+
+#[test]
+fn responses_request_to_codex_strips_prompt_cache_retention() {
+    let input = json!({
+        "model": "gpt-5",
+        "input": "hi",
+        "prompt_cache_retention": "24h",
+        "previous_response_id": "resp_123",
+        "safety_identifier": "sid_1"
+    });
+    let bytes = Bytes::from(input.to_string());
+    let output = responses_request_to_codex(&bytes, Some("gpt-5-codex")).expect("convert");
+    let value: serde_json::Value = serde_json::from_slice(&output).expect("json");
+    assert!(value.get("prompt_cache_retention").is_none());
+    assert!(value.get("previous_response_id").is_none());
+    assert!(value.get("safety_identifier").is_none());
 }


### PR DESCRIPTION
## Summary
- support top-level tool name/description/parameters/strict for Responses inputs
- avoid empty tool names in Responses tool_choice/tools mapping
- strip unsupported prompt_cache_retention/previous_response_id/safety_identifier before Codex upstream

## Testing
- cargo test -q responses_request_to_codex_uses_top_level_tool_name
- cargo test -q responses_request_to_codex_strips_prompt_cache_retention