### PR TITLE
fix(ci): Release workflow uses workspace Cargo.lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,7 +287,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git fetch origin "$branch" || true
           git switch -C "$branch"
-          git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json src-tauri/Cargo.lock
+          git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json Cargo.lock
           git commit -m "chore: release v${version}"
           git push --force-with-lease=refs/heads/$branch origin "HEAD:$branch"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"

--- a/scripts/versioning.mjs
+++ b/scripts/versioning.mjs
@@ -15,7 +15,8 @@ const PATHS = {
   packageJson: path.join(ROOT, "package.json"),
   tauriConf: path.join(ROOT, "src-tauri", "tauri.conf.json"),
   cargoToml: path.join(ROOT, "src-tauri", "Cargo.toml"),
-  cargoLock: path.join(ROOT, "src-tauri", "Cargo.lock"),
+  // 本仓库是 Cargo workspace，锁文件默认位于 workspace 根目录而不是成员 crate 目录。
+  cargoLock: path.join(ROOT, "Cargo.lock"),
 };
 
 function readJson(filePath) {


### PR DESCRIPTION
修复 Release workflow 在 workflow_dispatch 下执行 `node scripts/versioning.mjs release` 时找不到 `src-tauri/Cargo.lock` 的问题（本仓库是 Cargo workspace，锁文件位于根目录 `Cargo.lock`）。

- scripts/versioning.mjs：读取/写入根 Cargo.lock
- .github/workflows/release.yml：提交根 Cargo.lock 到 release 分支

对应失败日志：Prepare release PR 步骤报 ENOENT /src-tauri/Cargo.lock