### PR TITLE
fix: prevent stream request log loss on early disconnect

### DIFF
--- a/crates/token_proxy_core/src/proxy/codex_compat/stream.rs
+++ b/crates/token_proxy_core/src/proxy/codex_compat/stream.rs
@@ -7,6 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::extract_tool_name_map_from_request_body;
 use super::super::log::{build_log_entry, LogContext, LogWriter};
+use super::super::response::STREAM_DROPPED_ERROR;
 use super::super::sse::SseEventParser;
 use super::super::token_rate::RequestTokenTracker;
 use super::super::usage::SseUsageCollector;
@@ -44,6 +45,23 @@ struct CodexToChatState<S> {
     logged: bool,
     upstream_ended: bool,
     tool_name_map: HashMap<String, String>,
+}
+
+impl<S> CodexToChatState<S> {
+    fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        self.logged = true;
+        let entry = build_log_entry(&self.context, self.collector.finish(), response_error);
+        self.log.clone().write_detached(entry);
+    }
+}
+
+impl<S> Drop for CodexToChatState<S> {
+    fn drop(&mut self) {
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
 }
 
 impl<S, E> CodexToChatState<S>
@@ -260,12 +278,7 @@ where
     }
 
     fn log_usage_once(&mut self) {
-        if self.logged {
-            return;
-        }
-        self.logged = true;
-        let entry = build_log_entry(&self.context, self.collector.finish(), None);
-        self.log.clone().write_detached(entry);
+        self.write_log_once(None);
     }
 }
 
@@ -297,6 +310,23 @@ struct CodexToResponsesState<S> {
     logged: bool,
     upstream_ended: bool,
     tool_name_map: HashMap<String, String>,
+}
+
+impl<S> CodexToResponsesState<S> {
+    fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        self.logged = true;
+        let entry = build_log_entry(&self.context, self.collector.finish(), response_error);
+        self.log.clone().write_detached(entry);
+    }
+}
+
+impl<S> Drop for CodexToResponsesState<S> {
+    fn drop(&mut self) {
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
 }
 
 impl<S, E> CodexToResponsesState<S>
@@ -401,12 +431,7 @@ where
     }
 
     fn log_usage_once(&mut self) {
-        if self.logged {
-            return;
-        }
-        self.logged = true;
-        let entry = build_log_entry(&self.context, self.collector.finish(), None);
-        self.log.clone().write_detached(entry);
+        self.write_log_once(None);
     }
 }
 

--- a/crates/token_proxy_core/src/proxy/gemini_compat/stream.rs
+++ b/crates/token_proxy_core/src/proxy/gemini_compat/stream.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 use std::{collections::VecDeque, sync::Arc};
 
 use crate::proxy::log::{build_log_entry, LogContext, LogWriter};
+use crate::proxy::response::STREAM_DROPPED_ERROR;
 use crate::proxy::sse::SseEventParser;
 use crate::proxy::token_rate::RequestTokenTracker;
 use crate::proxy::usage::SseUsageCollector;
@@ -75,6 +76,40 @@ struct ChatToGeminiState<S> {
     logged: bool,
     upstream_ended: bool,
     tool_calls: Vec<Option<ToolCallState>>,
+}
+
+impl<S> GeminiToChatState<S> {
+    fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        self.logged = true;
+        let entry = build_log_entry(&self.context, self.collector.finish(), response_error);
+        self.log.clone().write_detached(entry);
+    }
+}
+
+impl<S> Drop for GeminiToChatState<S> {
+    fn drop(&mut self) {
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
+}
+
+impl<S> ChatToGeminiState<S> {
+    fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        self.logged = true;
+        let entry = build_log_entry(&self.context, self.collector.finish(), response_error);
+        self.log.clone().write_detached(entry);
+    }
+}
+
+impl<S> Drop for ChatToGeminiState<S> {
+    fn drop(&mut self) {
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
 }
 
 impl<S, E> GeminiToChatState<S>
@@ -284,12 +319,7 @@ where
     }
 
     fn log_usage_once(&mut self) {
-        if self.logged {
-            return;
-        }
-        self.logged = true;
-        let entry = build_log_entry(&self.context, self.collector.finish(), None);
-        self.log.clone().write_detached(entry);
+        self.write_log_once(None);
     }
 }
 
@@ -479,12 +509,7 @@ where
     }
 
     fn log_usage_once(&mut self) {
-        if self.logged {
-            return;
-        }
-        self.logged = true;
-        let entry = build_log_entry(&self.context, self.collector.finish(), None);
-        self.log.clone().write_detached(entry);
+        self.write_log_once(None);
     }
 }
 

--- a/crates/token_proxy_core/src/proxy/response.rs
+++ b/crates/token_proxy_core/src/proxy/response.rs
@@ -194,6 +194,8 @@ mod token_count;
 mod upstream_read;
 mod upstream_stream;
 
+pub(crate) use streaming::STREAM_DROPPED_ERROR;
+
 // 单元测试拆到独立文件，使用 `#[path]` 以保持 `.test.rs` 命名约定。
 #[cfg(test)]
 #[path = "response.test.rs"]

--- a/crates/token_proxy_core/src/proxy/response.test.part2.rs
+++ b/crates/token_proxy_core/src/proxy/response.test.part2.rs
@@ -123,3 +123,53 @@ fn stream_gemini_to_anthropic_emits_single_input_json_delta_for_tool_calls() {
         assert!(input_json_deltas[0].contains("\"subagent_type\""));
     });
 }
+
+#[test]
+fn stream_responses_to_chat_persists_log_when_client_drops_stream_early() {
+    super::run_async(async {
+        let sqlite_pool = super::create_test_sqlite_pool().await;
+        let log = Arc::new(LogWriter::new(Some(sqlite_pool.clone())));
+        let context = LogContext {
+            path: "/v1/responses".to_string(),
+            provider: "openai-response".to_string(),
+            upstream_id: "unit-test".to_string(),
+            model: Some("unit-model".to_string()),
+            mapped_model: Some("unit-model".to_string()),
+            stream: true,
+            status: 200,
+            upstream_request_id: None,
+            request_headers: None,
+            request_body: None,
+            ttfb_ms: None,
+            start: Instant::now(),
+        };
+        let upstream = futures_util::stream::iter(vec![
+            Ok::<Bytes, std::io::Error>(Bytes::from(
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n",
+            )),
+            Ok(Bytes::from(
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\" world\"}\n\n",
+            )),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ]);
+        let token_tracker = crate::proxy::token_rate::TokenRateTracker::new()
+            .register(None, None)
+            .await;
+        {
+            let stream =
+                super::super::responses_to_chat::stream_responses_to_chat(upstream, context, log, token_tracker);
+            futures_util::pin_mut!(stream);
+            let first = stream
+                .next()
+                .await
+                .expect("first stream item")
+                .expect("stream ok");
+            assert!(!first.is_empty());
+        }
+        let count = super::wait_for_log_rows(&sqlite_pool, 1).await;
+        assert!(
+            count >= 1,
+            "responses_to_chat stream dropped early should still persist request log row, got {count}"
+        );
+    });
+}

--- a/crates/token_proxy_core/src/proxy/response.test.rs
+++ b/crates/token_proxy_core/src/proxy/response.test.rs
@@ -131,6 +131,74 @@ async fn read_first_usage_tokens(
     }
 }
 
+async fn wait_for_log_rows(pool: &SqlitePool, expected_min: i64) -> i64 {
+    let deadline = TokioInstant::now() + Duration::from_secs(2);
+    loop {
+        let row = sqlx::query("SELECT COUNT(*) AS count FROM request_logs")
+            .fetch_one(pool)
+            .await
+            .expect("count request_logs");
+        let count = row.try_get::<i64, _>("count").expect("count column");
+        if count >= expected_min {
+            return count;
+        }
+        if TokioInstant::now() >= deadline {
+            return count;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[test]
+fn stream_with_logging_persists_log_when_client_drops_stream_early() {
+    run_async(async {
+        let sqlite_pool = create_test_sqlite_pool().await;
+        let log = Arc::new(LogWriter::new(Some(sqlite_pool.clone())));
+        let context = LogContext {
+            path: "/v1/responses".to_string(),
+            provider: "openai-response".to_string(),
+            upstream_id: "unit-test".to_string(),
+            model: Some("unit-model".to_string()),
+            mapped_model: Some("unit-model".to_string()),
+            stream: true,
+            status: 200,
+            upstream_request_id: None,
+            request_headers: None,
+            request_body: None,
+            ttfb_ms: None,
+            start: Instant::now(),
+        };
+        let upstream = futures_util::stream::iter(vec![
+            Ok::<Bytes, std::io::Error>(Bytes::from(
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n",
+            )),
+            Ok(Bytes::from(
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\" world\"}\n\n",
+            )),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ]);
+        let token_tracker = super::super::token_rate::TokenRateTracker::new()
+            .register(None, None)
+            .await;
+        {
+            let stream =
+                super::streaming::stream_with_logging(upstream, context, log.clone(), token_tracker);
+            futures_util::pin_mut!(stream);
+            let first = stream
+                .next()
+                .await
+                .expect("first stream item")
+                .expect("stream ok");
+            assert!(!first.is_empty());
+        }
+        let count = wait_for_log_rows(&sqlite_pool, 1).await;
+        assert!(
+            count >= 1,
+            "stream dropped early should still persist request log row, got {count}"
+        );
+    });
+}
+
 #[test]
 fn stream_responses_to_chat_emits_role_delta_and_done_and_logs_usage() {
     run_async(async {

--- a/crates/token_proxy_core/src/proxy/response/anthropic_to_responses.rs
+++ b/crates/token_proxy_core/src/proxy/response/anthropic_to_responses.rs
@@ -7,6 +7,7 @@ use super::super::log::{build_log_entry, LogContext, LogWriter};
 use super::super::sse::SseEventParser;
 use super::super::token_rate::RequestTokenTracker;
 use super::super::usage::SseUsageCollector;
+use super::streaming::STREAM_DROPPED_ERROR;
 use format::{snapshot_to_output_item, usage_to_value, OutputItemSnapshot};
 
 mod format;
@@ -62,6 +63,24 @@ struct AnthropicToResponsesState<S> {
     sent_done: bool,
     logged: bool,
     upstream_ended: bool,
+}
+
+impl<S> AnthropicToResponsesState<S> {
+    fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        self.logged = true;
+        let entry = build_log_entry(&self.context, self.collector.finish(), response_error);
+        self.log.clone().write_detached(entry);
+    }
+}
+
+impl<S> Drop for AnthropicToResponsesState<S> {
+    fn drop(&mut self) {
+        // 客户端提前取消时 try_unfold 状态会直接 drop，这里做日志兜底。
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
 }
 
 impl<S, E> AnthropicToResponsesState<S>
@@ -556,12 +575,7 @@ where
     }
 
     fn log_usage_once(&mut self) {
-        if self.logged {
-            return;
-        }
-        self.logged = true;
-        let entry = build_log_entry(&self.context, self.collector.finish(), None);
-        self.log.clone().write_detached(entry);
+        self.write_log_once(None);
     }
 
     fn next_sequence_number(&mut self) -> u64 {

--- a/crates/token_proxy_core/src/proxy/response/chat_to_responses.rs
+++ b/crates/token_proxy_core/src/proxy/response/chat_to_responses.rs
@@ -7,6 +7,7 @@ use super::super::log::{build_log_entry, LogContext, LogWriter};
 use super::super::sse::SseEventParser;
 use super::super::token_rate::RequestTokenTracker;
 use super::super::usage::SseUsageCollector;
+use super::streaming::STREAM_DROPPED_ERROR;
 use format::{snapshot_to_output_item, usage_to_value, OutputItemSnapshot};
 use state_types::{FunctionCallOutput, MessageOutput};
 
@@ -48,6 +49,24 @@ struct ChatToResponsesState<S> {
     sent_done: bool,
     logged: bool,
     upstream_ended: bool,
+}
+
+impl<S> ChatToResponsesState<S> {
+    fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        self.logged = true;
+        let entry = build_log_entry(&self.context, self.collector.finish(), response_error);
+        self.log.clone().write_detached(entry);
+    }
+}
+
+impl<S> Drop for ChatToResponsesState<S> {
+    fn drop(&mut self) {
+        // 对齐 new-api 的兜底语义：流提前释放也应保留请求日志。
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
 }
 
 impl<S, E> ChatToResponsesState<S>
@@ -572,12 +591,7 @@ where
     }
 
     fn log_usage_once(&mut self) {
-        if self.logged {
-            return;
-        }
-        self.logged = true;
-        let entry = build_log_entry(&self.context, self.collector.finish(), None);
-        self.log.clone().write_detached(entry);
+        self.write_log_once(None);
     }
 
     fn next_sequence_number(&mut self) -> u64 {

--- a/crates/token_proxy_core/src/proxy/response/kiro_to_anthropic/kiro_to_anthropic_stream.rs
+++ b/crates/token_proxy_core/src/proxy/response/kiro_to_anthropic/kiro_to_anthropic_stream.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 
 use crate::proxy::kiro::{EventStreamDecoder, KiroUsage};
 use crate::proxy::log::{LogContext, LogWriter};
+use crate::proxy::response::STREAM_DROPPED_ERROR;
 use crate::proxy::token_rate::RequestTokenTracker;
 
 pub(super) const USAGE_UPDATE_CHAR_THRESHOLD: usize = 5000;
@@ -83,6 +84,12 @@ struct KiroToAnthropicState<S> {
     last_ping_len: usize,
     last_ping_time: Instant,
     last_reported_output_tokens: u64,
+}
+
+impl<S> Drop for KiroToAnthropicState<S> {
+    fn drop(&mut self) {
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
 }
 
 impl<S, E> KiroToAnthropicState<S>

--- a/crates/token_proxy_core/src/proxy/response/kiro_to_anthropic/kiro_to_anthropic_stream/kiro_to_anthropic_stream_blocks.rs
+++ b/crates/token_proxy_core/src/proxy/response/kiro_to_anthropic/kiro_to_anthropic_stream/kiro_to_anthropic_stream_blocks.rs
@@ -303,27 +303,6 @@ where
         self.sent_message_stop = true;
     }
 
-    pub(super) fn log_usage_once(&mut self) {
-        if self.logged {
-            return;
-        }
-        self.logged = true;
-        apply_usage_fallback(
-            &mut self.usage,
-            Some(&self.model),
-            self.estimated_input_tokens,
-            &self.content,
-            &self.reasoning,
-        );
-        let usage_snapshot = UsageSnapshot {
-            usage: usage_from_kiro(&self.usage),
-            cached_tokens: None,
-            usage_json: usage_json_from_kiro(&self.usage),
-        };
-        let entry = build_log_entry(&self.context, usage_snapshot, None);
-        self.log.clone().write_detached(entry);
-    }
-
     pub(super) fn maybe_emit_usage_ping(&mut self) {
         let len = self.raw_content.len();
         let should_send = len.saturating_sub(self.last_ping_len) >= USAGE_UPDATE_CHAR_THRESHOLD
@@ -353,5 +332,32 @@ where
 
         self.last_ping_len = len;
         self.last_ping_time = Instant::now();
+    }
+}
+
+impl<S> KiroToAnthropicState<S> {
+    pub(super) fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        self.logged = true;
+        apply_usage_fallback(
+            &mut self.usage,
+            Some(&self.model),
+            self.estimated_input_tokens,
+            &self.content,
+            &self.reasoning,
+        );
+        let usage_snapshot = UsageSnapshot {
+            usage: usage_from_kiro(&self.usage),
+            cached_tokens: None,
+            usage_json: usage_json_from_kiro(&self.usage),
+        };
+        let entry = build_log_entry(&self.context, usage_snapshot, response_error);
+        self.log.clone().write_detached(entry);
+    }
+
+    pub(super) fn log_usage_once(&mut self) {
+        self.write_log_once(None);
     }
 }

--- a/crates/token_proxy_core/src/proxy/response/responses_to_anthropic.rs
+++ b/crates/token_proxy_core/src/proxy/response/responses_to_anthropic.rs
@@ -11,6 +11,7 @@ use super::super::log::{build_log_entry, LogContext, LogWriter};
 use super::super::sse::SseEventParser;
 use super::super::token_rate::RequestTokenTracker;
 use super::super::usage::SseUsageCollector;
+use super::streaming::STREAM_DROPPED_ERROR;
 
 pub(super) fn stream_responses_to_anthropic<E>(
     upstream: impl futures_util::stream::Stream<Item = Result<Bytes, E>>
@@ -63,6 +64,24 @@ struct ResponsesToAnthropicState<S> {
     saw_tool_use: bool,
     stop_reason_override: Option<&'static str>,
     saw_reasoning_delta: bool,
+}
+
+impl<S> ResponsesToAnthropicState<S> {
+    fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        let entry = build_log_entry(&self.context, self.collector.finish(), response_error);
+        self.log.clone().write_detached(entry);
+        self.logged = true;
+    }
+}
+
+impl<S> Drop for ResponsesToAnthropicState<S> {
+    fn drop(&mut self) {
+        // 若下游中途取消，Drop 仍会触发，保证请求日志不丢。
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
 }
 
 impl<S, E> ResponsesToAnthropicState<S>
@@ -671,12 +690,7 @@ where
     }
 
     fn log_usage_once(&mut self) {
-        if self.logged {
-            return;
-        }
-        let entry = build_log_entry(&self.context, self.collector.finish(), None);
-        self.log.clone().write_detached(entry);
-        self.logged = true;
+        self.write_log_once(None);
     }
 }
 

--- a/crates/token_proxy_core/src/proxy/response/responses_to_chat.rs
+++ b/crates/token_proxy_core/src/proxy/response/responses_to_chat.rs
@@ -12,6 +12,7 @@ use super::super::log::{build_log_entry, LogContext, LogWriter};
 use super::super::sse::SseEventParser;
 use super::super::token_rate::RequestTokenTracker;
 use super::super::usage::SseUsageCollector;
+use super::streaming::STREAM_DROPPED_ERROR;
 
 pub(super) fn stream_responses_to_chat<E>(
     upstream: impl futures_util::stream::Stream<Item = Result<Bytes, E>>
@@ -60,6 +61,24 @@ struct ToolCallState {
     arguments: String,
     sent_initial: bool,
     sent_arguments: bool,
+}
+
+impl<S> ResponsesToChatState<S> {
+    fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        self.logged = true;
+        let entry = build_log_entry(&self.context, self.collector.finish(), response_error);
+        self.log.clone().write_detached(entry);
+    }
+}
+
+impl<S> Drop for ResponsesToChatState<S> {
+    fn drop(&mut self) {
+        // 兼容客户端提前断流：状态机未走到完成分支时也要落一条日志。
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
 }
 
 impl<S, E> ResponsesToChatState<S>
@@ -530,12 +549,7 @@ where
     }
 
     fn log_usage_once(&mut self) {
-        if self.logged {
-            return;
-        }
-        self.logged = true;
-        let entry = build_log_entry(&self.context, self.collector.finish(), None);
-        self.log.clone().write_detached(entry);
+        self.write_log_once(None);
     }
 
     fn finish_reason(&self) -> &'static str {

--- a/crates/token_proxy_core/src/proxy/response/streaming.rs
+++ b/crates/token_proxy_core/src/proxy/response/streaming.rs
@@ -13,6 +13,8 @@ use super::super::sse::SseEventParser;
 use super::super::token_rate::RequestTokenTracker;
 use super::super::usage::SseUsageCollector;
 
+pub(crate) const STREAM_DROPPED_ERROR: &str = "stream dropped before completion";
+
 pub(super) fn stream_with_logging<E>(
     upstream: impl futures_util::stream::Stream<Item = Result<Bytes, E>> + Unpin + Send + 'static,
     context: LogContext,
@@ -22,62 +24,109 @@ pub(super) fn stream_with_logging<E>(
 where
     E: std::error::Error + Send + Sync + 'static,
 {
-    let collector = SseUsageCollector::new();
-    let parser = SseEventParser::new();
-    try_unfold(
-        (upstream, collector, parser, log, context, token_tracker),
-        |(mut upstream, mut collector, mut parser, log, mut context, token_tracker)| async move {
-            match upstream.next().await {
-                Some(Ok(chunk)) => {
-                    if context.ttfb_ms.is_none() {
-                        context.ttfb_ms = Some(context.start.elapsed().as_millis());
-                    }
-                    collector.push_chunk(&chunk);
-                    let provider = context.provider.as_str();
-                    let mut texts = Vec::new();
-                    parser.push_chunk(&chunk, |data| {
-                        if let Some(text) = extract_stream_text(provider, &data) {
-                            texts.push(text);
-                        }
-                    });
-                    for text in texts {
-                        token_tracker.add_output_text(&text).await;
-                    }
-                    Ok(Some((chunk, (upstream, collector, parser, log, context, token_tracker))))
+    let state = LoggingStreamState::new(upstream, context, log, token_tracker);
+    try_unfold(state, |state| async move { state.step().await })
+}
+
+struct LoggingStreamState<S> {
+    upstream: S,
+    collector: SseUsageCollector,
+    parser: SseEventParser,
+    log: Arc<LogWriter>,
+    context: LogContext,
+    token_tracker: RequestTokenTracker,
+    logged: bool,
+}
+
+impl<S> LoggingStreamState<S> {
+    fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        let entry = build_log_entry(&self.context, self.collector.finish(), response_error);
+        self.log.clone().write_detached(entry);
+        self.logged = true;
+    }
+}
+
+impl<S> Drop for LoggingStreamState<S> {
+    fn drop(&mut self) {
+        // 流被客户端提前取消时不会再进入 `None/Err` 分支，这里兜底保证日志至少落一行。
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
+}
+
+impl<S, E> LoggingStreamState<S>
+where
+    S: futures_util::stream::Stream<Item = Result<Bytes, E>> + Unpin + Send + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn new(
+        upstream: S,
+        context: LogContext,
+        log: Arc<LogWriter>,
+        token_tracker: RequestTokenTracker,
+    ) -> Self {
+        Self {
+            upstream,
+            collector: SseUsageCollector::new(),
+            parser: SseEventParser::new(),
+            log,
+            context,
+            token_tracker,
+            logged: false,
+        }
+    }
+
+    async fn step(mut self) -> Result<Option<(Bytes, Self)>, std::io::Error> {
+        match self.upstream.next().await {
+            Some(Ok(chunk)) => {
+                if self.context.ttfb_ms.is_none() {
+                    self.context.ttfb_ms = Some(self.context.start.elapsed().as_millis());
                 }
-                Some(Err(err)) => {
-                    let provider = context.provider.as_str();
-                    let mut texts = Vec::new();
-                    parser.finish(|data| {
-                        if let Some(text) = extract_stream_text(provider, &data) {
-                            texts.push(text);
-                        }
-                    });
-                    for text in texts {
-                        token_tracker.add_output_text(&text).await;
+                self.collector.push_chunk(&chunk);
+                let provider = self.context.provider.as_str();
+                let mut texts = Vec::new();
+                self.parser.push_chunk(&chunk, |data| {
+                    if let Some(text) = extract_stream_text(provider, &data) {
+                        texts.push(text);
                     }
-                    let entry = build_log_entry(&context, collector.finish(), None);
-                    log.clone().write_detached(entry);
-                    Err(std::io::Error::new(std::io::ErrorKind::Other, err))
+                });
+                for text in texts {
+                    self.token_tracker.add_output_text(&text).await;
                 }
-                None => {
-                    let provider = context.provider.as_str();
-                    let mut texts = Vec::new();
-                    parser.finish(|data| {
-                        if let Some(text) = extract_stream_text(provider, &data) {
-                            texts.push(text);
-                        }
-                    });
-                    for text in texts {
-                        token_tracker.add_output_text(&text).await;
-                    }
-                    let entry = build_log_entry(&context, collector.finish(), None);
-                    log.clone().write_detached(entry);
-                    Ok(None)
-                }
+                Ok(Some((chunk, self)))
             }
-        },
-    )
+            Some(Err(err)) => {
+                let provider = self.context.provider.as_str();
+                let mut texts = Vec::new();
+                self.parser.finish(|data| {
+                    if let Some(text) = extract_stream_text(provider, &data) {
+                        texts.push(text);
+                    }
+                });
+                for text in texts {
+                    self.token_tracker.add_output_text(&text).await;
+                }
+                self.write_log_once(None);
+                Err(std::io::Error::new(std::io::ErrorKind::Other, err))
+            }
+            None => {
+                let provider = self.context.provider.as_str();
+                let mut texts = Vec::new();
+                self.parser.finish(|data| {
+                    if let Some(text) = extract_stream_text(provider, &data) {
+                        texts.push(text);
+                    }
+                });
+                for text in texts {
+                    self.token_tracker.add_output_text(&text).await;
+                }
+                self.write_log_once(None);
+                Ok(None)
+            }
+        }
+    }
 }
 
 pub(super) fn stream_with_logging_and_model_override<E>(
@@ -105,6 +154,24 @@ struct ModelOverrideStreamState<S> {
     model_override: String,
     upstream_ended: bool,
     logged: bool,
+}
+
+impl<S> ModelOverrideStreamState<S> {
+    fn write_log_once(&mut self, response_error: Option<String>) {
+        if self.logged {
+            return;
+        }
+        let entry = build_log_entry(&self.context, self.collector.finish(), response_error);
+        self.log.clone().write_detached(entry);
+        self.logged = true;
+    }
+}
+
+impl<S> Drop for ModelOverrideStreamState<S> {
+    fn drop(&mut self) {
+        // 和基础流一致：提前 drop 也必须落日志，避免“请求发生但无日志行”。
+        self.write_log_once(Some(STREAM_DROPPED_ERROR.to_string()));
+    }
 }
 
 impl<S, E> ModelOverrideStreamState<S>
@@ -139,7 +206,7 @@ where
                 return Ok(Some((next, self)));
             }
             if self.upstream_ended {
-                self.log_usage_once();
+                self.write_log_once(None);
                 return Ok(None);
             }
 
@@ -163,7 +230,7 @@ where
                     }
                 }
                 Some(Err(err)) => {
-                    self.log_usage_once();
+                    self.write_log_once(None);
                     return Err(std::io::Error::new(std::io::ErrorKind::Other, err));
                 }
                 None => {
@@ -190,14 +257,6 @@ where
         self.out.push_back(Bytes::from(format!("data: {output}\n\n")));
     }
 
-    fn log_usage_once(&mut self) {
-        if self.logged {
-            return;
-        }
-        let entry = build_log_entry(&self.context, self.collector.finish(), None);
-        self.log.clone().write_detached(entry);
-        self.logged = true;
-    }
 }
 
 fn rewrite_sse_data(data: &str, model_override: &str) -> String {


### PR DESCRIPTION
## 背景
用户反馈在流式请求（尤其是 `/v1/responses`）提前中断时，存在“请求发生但日志未入库”的问题。

## 变更
- 为流式日志路径增加 `Drop` 兜底落库机制，避免仅依赖 `None/Err` 分支。
- 统一将该兜底语义扩展到：
  - 基础流与 model override 流
  - responses/chat/anthropic 转换流
  - codex/gemini/kiro 兼容流
- 兜底日志标记 `response_error = "stream dropped before completion"`。
- 新增中断场景回归测试（基础流 + 转换流）。

## 验证
- `cargo test -p token_proxy_core proxy::response::tests:: -- --nocapture`
- `cargo test -p token_proxy_core`
