### PR TITLE
fix: tray show opens main window on first click

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,14 +71,17 @@ pub(crate) fn show_or_create_main_window(app: &tauri::AppHandle) {
     std::thread::spawn(move || {
         let result =
             tauri::WebviewWindowBuilder::from_config(&app_handle, &config).and_then(|builder| {
-                builder.build()?;
+                let window = builder.build()?;
+                set_main_window_visibility(&app_handle, true);
+                let _ = window.unminimize();
+                let _ = window.show();
+                let _ = window.set_focus();
                 Ok(())
             });
         if let Err(err) = result {
             tracing::warn!(error = %err, "create main window failed");
             return;
         }
-        set_main_window_visibility(&app_handle, true);
         sync_main_window_menu_item(&app_handle);
     });
 }


### PR DESCRIPTION
## Problem
When the main window has been hidden/destroyed, clicking tray "显示主窗口" the first time may only recreate the window object but not actually present it, so users have to click twice.

## Root cause
The create path only built the window and synced menu state. Since `tauri.conf.json` sets `visible: false`, a newly created window can stay hidden unless we explicitly show/focus it.

## Fix
- In the create path of `show_or_create_main_window`, capture the newly built window
- Explicitly call `unminimize()`, `show()`, and `set_focus()`
- Keep menu sync after successful creation

## Verification
- `cargo check -q -p token_proxy`
- `cargo test -q -p token_proxy tray::tests`
