### PR TITLE
[codex] fix stale gpt display-name test

### DIFF
--- a/src-tauri/src/client_config.rs
+++ b/src-tauri/src/client_config.rs
@@ -652,7 +652,7 @@ mod tests {
             .expect("gpt display name");
 
         assert_eq!(claude_name, "Claude Sonnet 4 5");
-        assert_eq!(gpt_name, "Gpt 5.2 Codex");
+        assert_eq!(gpt_name, "Gpt 5.4");
     }
 
     #[test]


### PR DESCRIPTION
## 问题
`#196` 合并后，`main` 上的 `Test` workflow 失败，导致后续 release 链路被阻断。失败点不在账户优先级主链路，而是在 `src-tauri/src/client_config.rs` 的测试 `opencode_provider_uses_readable_model_display_names`。

## 根因
此前默认模型已从 `gpt-5.2-codex` 调整为 `gpt-5.4`，但该测试的预期字符串仍停留在旧值 `Gpt 5.2 Codex`，因此在 `main` 和 release commit 上都会稳定失败。

## 修复
把过期的测试预期同步到当前实际模型展示名 `Gpt 5.4`。本次 PR 只包含这一个测试修复，不改业务逻辑。

## 验证
- `cargo test -p token_proxy client_config::tests:: -- --nocapture`
