### PR TITLE
[codex] fix release guard and republish v0.1.63

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,14 @@ on:
       version:
         description: "Release version (e.g., 0.1.0)"
         required: true
+      republish:
+        description: "Republish an existing stable tag instead of preparing a release PR"
+        required: false
+        default: "false"
+
+concurrency:
+  group: release-${{ github.event_name }}-${{ github.event.workflow_run.head_branch || github.ref_name || 'manual' }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,25 +26,58 @@ env:
 
 jobs:
   stable_tag:
-    name: Tag release (main push)
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
+    name: Resolve release context
+    if: |
+      (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push') ||
+      (github.event_name == 'workflow_dispatch' && inputs.republish == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     outputs:
-      version: ${{ steps.release_guard.outputs.version }}
-      tag: ${{ steps.create_tag.outputs.tag }}
+      version: ${{ steps.release_guard.outputs.version || steps.manual_release.outputs.version }}
+      tag: ${{ steps.create_tag.outputs.tag || steps.manual_release.outputs.tag }}
       release_notes: ${{ steps.release_notes.outputs.release_body }}
       release_matrix: ${{ steps.release_matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+        if: github.event_name == 'workflow_run'
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          fetch-depth: 0
+          ref: v${{ inputs.version }}
+
       - name: Release guard
+        if: github.event_name == 'workflow_run'
         id: release_guard
         run: node scripts/release-guard.mjs
+
+      - name: Resolve manual release context
+        if: github.event_name == 'workflow_dispatch'
+        id: manual_release
+        shell: bash
+        run: |
+          version="${{ inputs.version }}"
+          tag="v${version}"
+
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Republish version must be x.y.z, got: $version" >&2
+            exit 1
+          fi
+
+          if ! git rev-parse "$tag^{object}" >/dev/null 2>&1; then
+            echo "Tag $tag does not exist on origin." >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Abort if not a release commit
         if: steps.release_guard.outputs.is_release != 'true'
@@ -46,15 +87,16 @@ jobs:
 
       - name: Resolve previous stable tag
         id: previous_tag
-        if: steps.release_guard.outputs.is_release == 'true'
+        if: steps.release_guard.outputs.is_release == 'true' || github.event_name == 'workflow_dispatch'
         run: |
+          current_tag="${{ steps.create_tag.outputs.tag || steps.manual_release.outputs.tag || format('v{0}', steps.release_guard.outputs.version) }}"
           tags=$(git tag --list 'v*' --sort=v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
-          prev=$(echo "$tags" | tail -n 1)
+          prev=$(echo "$tags" | grep -vx "$current_tag" | tail -n 1)
           echo "previous_tag=$prev" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag
         id: create_tag
-        if: steps.release_guard.outputs.is_release == 'true'
+        if: github.event_name == 'workflow_run' && steps.release_guard.outputs.is_release == 'true'
         run: |
           tag="v${{ steps.release_guard.outputs.version }}"
           git config --local user.email "action@github.com"
@@ -65,10 +107,10 @@ jobs:
 
       - name: Generate release notes
         id: release_notes
-        if: steps.release_guard.outputs.is_release == 'true'
+        if: steps.release_guard.outputs.is_release == 'true' || github.event_name == 'workflow_dispatch'
         uses: actions/github-script@v7
         env:
-          RELEASE_TAG: ${{ steps.create_tag.outputs.tag }}
+          RELEASE_TAG: ${{ steps.create_tag.outputs.tag || steps.manual_release.outputs.tag }}
           PREVIOUS_TAG: ${{ steps.previous_tag.outputs.previous_tag }}
         with:
           script: |
@@ -89,7 +131,7 @@ jobs:
       # 避免新增/删减平台时出现两处配置漂移。
       - name: Export release matrix
         id: release_matrix
-        if: steps.release_guard.outputs.is_release == 'true'
+        if: steps.release_guard.outputs.is_release == 'true' || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           {
@@ -390,7 +432,7 @@ jobs:
 
   prepare_release_pr:
     name: Prepare release PR
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.republish != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 function setOutput(key, value) {
   const outputPath = process.env.GITHUB_OUTPUT;
@@ -16,21 +17,62 @@ function readPackageVersion() {
   return pkg.version;
 }
 
-function latestTag() {
-  const output = execSync("git tag --list 'v*' --sort=-v:refname | head -n 1", {
+function readHeadCommitSubject() {
+  return execSync("git log -1 --pretty=%s", {
     encoding: "utf8",
   }).trim();
+}
+
+function latestTag() {
+  const output = execSync(
+    "git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\\.[0-9]+\\.[0-9]+$' | head -n 1",
+    {
+      encoding: "utf8",
+    }
+  ).trim();
   return output || "";
 }
 
-const version = readPackageVersion();
-const isPrerelease = version.includes("-");
-const currentTag = `v${version}`;
-const newestTag = latestTag();
-const isNewRelease = !isPrerelease && newestTag !== currentTag;
+export function parseReleaseCommitVersion(commitSubject) {
+  const match = commitSubject.match(
+    /^chore: release v(\d+\.\d+\.\d+)(?: \(\#\d+\))?$/
+  );
+  return match?.[1] ?? "";
+}
 
-setOutput("version", version);
-setOutput("latest_tag", newestTag);
-setOutput("is_release", isNewRelease ? "true" : "false");
-// For backward compatibility with prerelease job gating: skip prerelease when this is a new release commit.
-setOutput("skip", isNewRelease ? "true" : "false");
+export function evaluateReleaseGuard({ version, newestTag, commitSubject }) {
+  const isPrerelease = version.includes("-");
+  const currentTag = `v${version}`;
+  const releaseCommitVersion = parseReleaseCommitVersion(commitSubject);
+  const isReleaseCommit = releaseCommitVersion === version;
+  const isNewRelease = !isPrerelease && isReleaseCommit && newestTag !== currentTag;
+  return {
+    currentTag,
+    isPrerelease,
+    isRelease: isNewRelease,
+    releaseCommitVersion,
+  };
+}
+
+function main() {
+  const version = readPackageVersion();
+  const newestTag = latestTag();
+  const commitSubject = readHeadCommitSubject();
+  const result = evaluateReleaseGuard({
+    version,
+    newestTag,
+    commitSubject,
+  });
+
+  setOutput("version", version);
+  setOutput("latest_tag", newestTag);
+  setOutput("commit_subject", commitSubject);
+  setOutput("release_commit_version", result.releaseCommitVersion);
+  setOutput("is_release", result.isRelease ? "true" : "false");
+  // For backward compatibility with prerelease job gating: skip prerelease when this is a new release commit.
+  setOutput("skip", result.isRelease ? "true" : "false");
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/scripts/release-guard.test.mjs
+++ b/scripts/release-guard.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluateReleaseGuard,
+  parseReleaseCommitVersion,
+} from "./release-guard.mjs";
+
+test("parseReleaseCommitVersion 只接受 release 提交标题", () => {
+  assert.equal(
+    parseReleaseCommitVersion("chore: release v0.1.63 (#199)"),
+    "0.1.63"
+  );
+  assert.equal(
+    parseReleaseCommitVersion("fix stale gpt display-name test (#198)"),
+    ""
+  );
+});
+
+test("evaluateReleaseGuard 对真正的 release merge commit 放行", () => {
+  assert.deepEqual(
+    evaluateReleaseGuard({
+      version: "0.1.63",
+      newestTag: "v0.1.62",
+      commitSubject: "chore: release v0.1.63 (#199)",
+    }),
+    {
+      currentTag: "v0.1.63",
+      isPrerelease: false,
+      isRelease: true,
+      releaseCommitVersion: "0.1.63",
+    }
+  );
+});
+
+test("evaluateReleaseGuard 跳过普通 main push，即使版本号还领先最新 tag", () => {
+  assert.deepEqual(
+    evaluateReleaseGuard({
+      version: "0.1.62",
+      newestTag: "v0.1.61",
+      commitSubject: "fix stale gpt display-name test (#198)",
+    }),
+    {
+      currentTag: "v0.1.62",
+      isPrerelease: false,
+      isRelease: false,
+      releaseCommitVersion: "",
+    }
+  );
+});
+
+test("evaluateReleaseGuard 跳过标题和 package 版本不一致的提交", () => {
+  assert.deepEqual(
+    evaluateReleaseGuard({
+      version: "0.1.63",
+      newestTag: "v0.1.62",
+      commitSubject: "chore: release v0.1.64 (#200)",
+    }),
+    {
+      currentTag: "v0.1.63",
+      isPrerelease: false,
+      isRelease: false,
+      releaseCommitVersion: "0.1.64",
+    }
+  );
+});


### PR DESCRIPTION
## 问题
- 0.1.63 这次自动发布实际先跑到了一条错误的 workflow_run，上游 checkout 到 #198 的 hotfix commit，并把它误判成 v0.1.62 release
- 真正对应 `chore: release v0.1.63 (#199)` 的 workflow_run 后续被取消，导致 v0.1.63 release 只剩 1 个 arm64 CLI 资产

## 根因
- `scripts/release-guard.mjs` 只看 package 版本是否领先最新 stable tag，没有要求 HEAD commit 本身就是 release commit
- `Release` workflow 没有并发收敛，两个紧邻的 main push 都完成 Test 时，会同时起两条 workflow_run
- 现有 workflow_dispatch 只能准备新的 release PR，不能对已存在的 stable tag 做补发

## 修复
- 收紧 `release-guard`：只有 `chore: release vX.Y.Z` 且与 package 版本一致时才允许自动打 tag/发版
- 为 `Release` workflow 增加 concurrency，自动取消同一条 main 发布线上的旧 run
- 为 workflow_dispatch 增加 `republish=true` 路径，支持直接对已有 stable tag 重新生成/上传完整 release 资产
- 新增 `scripts/release-guard.test.mjs` 覆盖误判 hotfix commit 和正常 release commit 两个核心场景

## 验证
- `node --test scripts/release-guard.test.mjs`
- `node scripts/release-guard.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok"'`