### PR TITLE
[codex] support compact responses codex routing

### DIFF
--- a/crates/token_proxy_core/src/proxy/codex_compat.rs
+++ b/crates/token_proxy_core/src/proxy/codex_compat.rs
@@ -8,7 +8,9 @@ mod stream;
 mod tool_names;
 
 pub(crate) use headers::apply_codex_headers;
-pub(crate) use request::{chat_request_to_codex, responses_request_to_codex};
+pub(crate) use request::{
+    chat_request_to_codex, responses_compact_request_to_codex, responses_request_to_codex,
+};
 pub(crate) use response::{codex_response_to_chat, codex_response_to_responses};
 pub(crate) use stream::{
     stream_chat_error_sse, stream_codex_to_chat, stream_codex_to_responses,

--- a/crates/token_proxy_core/src/proxy/codex_compat/request.rs
+++ b/crates/token_proxy_core/src/proxy/codex_compat/request.rs
@@ -76,8 +76,23 @@ pub(crate) fn responses_request_to_codex(
     body: &Bytes,
     model_hint: Option<&str>,
 ) -> Result<Bytes, String> {
+    transform_responses_request_to_codex(body, model_hint, false)
+}
+
+pub(crate) fn responses_compact_request_to_codex(
+    body: &Bytes,
+    model_hint: Option<&str>,
+) -> Result<Bytes, String> {
+    transform_responses_request_to_codex(body, model_hint, true)
+}
+
+fn transform_responses_request_to_codex(
+    body: &Bytes,
+    model_hint: Option<&str>,
+    strip_reasoning_include: bool,
+) -> Result<Bytes, String> {
     let mut object = parse_object(body)?;
-    normalize_responses_payload(&mut object, model_hint);
+    normalize_responses_payload(&mut object, model_hint, strip_reasoning_include);
     let tool_map = build_tool_name_map(&object);
 
     if let Some(tools) = object.get("tools").cloned() {
@@ -404,22 +419,32 @@ fn apply_text_format(
     }
 }
 
-fn normalize_responses_payload(object: &mut Map<String, Value>, model_hint: Option<&str>) {
+fn normalize_responses_payload(
+    object: &mut Map<String, Value>,
+    model_hint: Option<&str>,
+    strip_reasoning_include: bool,
+) {
     let model = object
         .get("model")
         .and_then(Value::as_str)
         .or(model_hint)
         .unwrap_or_default();
     object.insert("model".to_string(), Value::String(model.to_string()));
-    object.insert("stream".to_string(), Value::Bool(true));
-    object.insert("store".to_string(), Value::Bool(false));
     if !object.contains_key("parallel_tool_calls") {
         object.insert("parallel_tool_calls".to_string(), Value::Bool(true));
     }
-    object.insert(
-        "include".to_string(),
-        json!(["reasoning.encrypted_content"]),
-    );
+    if strip_reasoning_include {
+        object.remove("include");
+        object.remove("store");
+        object.remove("stream");
+    } else {
+        object.insert("stream".to_string(), Value::Bool(true));
+        object.insert("store".to_string(), Value::Bool(false));
+        object.insert(
+            "include".to_string(),
+            json!(["reasoning.encrypted_content"]),
+        );
+    }
     for key in [
         "max_output_tokens",
         "max_completion_tokens",

--- a/crates/token_proxy_core/src/proxy/openai.rs
+++ b/crates/token_proxy_core/src/proxy/openai.rs
@@ -1,4 +1,5 @@
 const OPENAI_RESPONSES_ROOT: &str = "/v1/responses";
+const OPENAI_RESPONSES_COMPACT_ROOT: &str = "/v1/responses/compact";
 const OPENAI_CHAT_COMPLETIONS_ROOT: &str = "/v1/chat/completions";
 
 const OPENAI_NATIVE_PREFIX_ROOTS: &[&str] = &[
@@ -21,7 +22,11 @@ const OPENAI_NATIVE_PREFIX_ROOTS: &[&str] = &[
 
 pub(crate) fn is_openai_responses_resource_path(path: &str) -> bool {
     let path = strip_query(path);
-    path.starts_with(&format!("{OPENAI_RESPONSES_ROOT}/"))
+    path != OPENAI_RESPONSES_COMPACT_ROOT && path.starts_with(&format!("{OPENAI_RESPONSES_ROOT}/"))
+}
+
+pub(crate) fn is_openai_responses_compact_path(path: &str) -> bool {
+    strip_query(path) == OPENAI_RESPONSES_COMPACT_ROOT
 }
 
 pub(crate) fn is_openai_native_resource_path(path: &str) -> bool {

--- a/crates/token_proxy_core/src/proxy/openai_compat.rs
+++ b/crates/token_proxy_core/src/proxy/openai_compat.rs
@@ -15,6 +15,7 @@ pub(crate) use usage::map_usage_chat_to_responses;
 
 pub(crate) const CHAT_PATH: &str = "/v1/chat/completions";
 pub(crate) const RESPONSES_PATH: &str = "/v1/responses";
+pub(crate) const RESPONSES_COMPACT_PATH: &str = "/v1/responses/compact";
 
 pub(crate) const PROVIDER_CHAT: &str = "openai";
 pub(crate) const PROVIDER_RESPONSES: &str = "openai-response";
@@ -44,17 +45,23 @@ pub(crate) enum FormatTransform {
     KiroToAnthropic,
     ChatToCodex,
     ResponsesToCodex,
+    ResponsesCompactToCodex,
     CodexToChat,
     CodexToResponses,
     CodexToAnthropic,
 }
 
 pub(crate) fn inbound_format(path: &str) -> Option<ApiFormat> {
+    let path = strip_query(path);
     match path {
         CHAT_PATH => Some(ApiFormat::ChatCompletions),
-        RESPONSES_PATH => Some(ApiFormat::Responses),
+        RESPONSES_PATH | RESPONSES_COMPACT_PATH => Some(ApiFormat::Responses),
         _ => None,
     }
+}
+
+fn strip_query(path: &str) -> &str {
+    path.split_once('?').map(|(path, _)| path).unwrap_or(path)
 }
 
 pub(crate) async fn transform_request_body(
@@ -99,6 +106,9 @@ pub(crate) async fn transform_request_body(
         FormatTransform::ChatToCodex => codex_compat::chat_request_to_codex(body, model_hint),
         FormatTransform::ResponsesToCodex => {
             codex_compat::responses_request_to_codex(body, model_hint)
+        }
+        FormatTransform::ResponsesCompactToCodex => {
+            codex_compat::responses_compact_request_to_codex(body, model_hint)
         }
         FormatTransform::CodexToChat
         | FormatTransform::CodexToResponses
@@ -148,7 +158,9 @@ pub(crate) fn transform_response_body(
         FormatTransform::CodexToChat | FormatTransform::CodexToResponses => {
             Err("Codex response conversion is handled upstream.".to_string())
         }
-        FormatTransform::ChatToCodex | FormatTransform::ResponsesToCodex => {
+        FormatTransform::ChatToCodex
+        | FormatTransform::ResponsesToCodex
+        | FormatTransform::ResponsesCompactToCodex => {
             Err("Codex response conversion is handled upstream.".to_string())
         }
     }

--- a/crates/token_proxy_core/src/proxy/openai_compat.test.part1.rs
+++ b/crates/token_proxy_core/src/proxy/openai_compat.test.part1.rs
@@ -852,3 +852,53 @@ fn transform_request_body_rejects_non_json() {
     });
     assert!(err.contains("JSON"));
 }
+
+#[test]
+fn responses_compact_to_codex_strips_reasoning_include() {
+    let http_clients = ProxyHttpClients::new().expect("http clients");
+    let input = bytes_from_json(json!({
+        "model": "gpt-5.4",
+        "input": "compact me",
+        "include": ["reasoning.encrypted_content"]
+    }));
+
+    let output = run_async(async {
+        transform_request_body(
+            FormatTransform::ResponsesCompactToCodex,
+            &input,
+            &http_clients,
+            Some("gpt-5-codex"),
+        )
+        .await
+        .expect("transform")
+    });
+    let value = json_from_bytes(output);
+
+    assert!(value.get("include").is_none());
+    assert!(value.get("store").is_none());
+    assert!(value.get("stream").is_none());
+    assert_eq!(value["model"], json!("gpt-5.4"));
+}
+
+#[test]
+fn responses_to_codex_keeps_reasoning_include() {
+    let http_clients = ProxyHttpClients::new().expect("http clients");
+    let input = bytes_from_json(json!({
+        "model": "gpt-5.4",
+        "input": "keep include"
+    }));
+
+    let output = run_async(async {
+        transform_request_body(
+            FormatTransform::ResponsesToCodex,
+            &input,
+            &http_clients,
+            Some("gpt-5-codex"),
+        )
+        .await
+        .expect("transform")
+    });
+    let value = json_from_bytes(output);
+
+    assert_eq!(value["include"], json!(["reasoning.encrypted_content"]));
+}

--- a/crates/token_proxy_core/src/proxy/response/dispatch/stream.rs
+++ b/crates/token_proxy_core/src/proxy/response/dispatch/stream.rs
@@ -123,6 +123,7 @@ fn is_simple_transform(transform: FormatTransform) -> bool {
             | FormatTransform::CodexToResponses
             | FormatTransform::ChatToCodex
             | FormatTransform::ResponsesToCodex
+            | FormatTransform::ResponsesCompactToCodex
     )
 }
 
@@ -234,7 +235,9 @@ fn stream_for_simple_extended(
         FormatTransform::CodexToResponses => {
             codex_compat::stream_codex_to_responses(upstream, context, log, request_tracker).boxed()
         }
-        FormatTransform::ChatToCodex | FormatTransform::ResponsesToCodex => {
+        FormatTransform::ChatToCodex
+        | FormatTransform::ResponsesToCodex
+        | FormatTransform::ResponsesCompactToCodex => {
             streaming::stream_with_logging(upstream, context, log, request_tracker).boxed()
         }
         _ => streaming::stream_with_logging(upstream, context, log, request_tracker).boxed(),

--- a/crates/token_proxy_core/src/proxy/server.rs
+++ b/crates/token_proxy_core/src/proxy/server.rs
@@ -36,6 +36,7 @@ const PROVIDER_CODEX: &str = "codex";
 const PROVIDER_PROXY: &str = "proxy";
 const LOCAL_UPSTREAM_ID: &str = "local";
 const CODEX_RESPONSES_PATH: &str = "/responses";
+const CODEX_RESPONSES_COMPACT_PATH: &str = "/responses/compact";
 
 type ProxyStateHandle = Arc<RwLock<Arc<ProxyState>>>;
 
@@ -234,6 +235,16 @@ fn resolve_openai_native_plan(
     None
 }
 
+fn resolve_responses_compact_plan(
+    config: &ProxyConfig,
+    path: &str,
+) -> Option<Result<DispatchPlan, String>> {
+    if !openai::is_openai_responses_compact_path(path) {
+        return None;
+    }
+    Some(resolve_responses_native_plan(config))
+}
+
 fn resolve_anthropic_plan(
     config: &ProxyConfig,
     path: &str,
@@ -400,6 +411,9 @@ fn resolve_dispatch_plan_with_request(
     if let Some(plan) = resolve_models_plan(config, path, headers, query) {
         return plan;
     }
+    if let Some(plan) = resolve_responses_compact_plan(config, path) {
+        return plan;
+    }
     if let Some(plan) = resolve_openai_native_plan(config, path) {
         return plan;
     }
@@ -419,9 +433,36 @@ fn resolve_dispatch_plan_with_request(
 
     match format {
         InboundApiFormat::OpenaiChat => resolve_chat_plan(config),
-        InboundApiFormat::OpenaiResponses => resolve_responses_plan(config),
+        InboundApiFormat::OpenaiResponses => {
+            if openai::is_openai_responses_compact_path(path) {
+                resolve_responses_native_plan(config)
+            } else {
+                resolve_responses_plan(config)
+            }
+        }
         _ => resolve_formatless_plan(config),
     }
+}
+
+fn resolve_responses_native_plan(config: &ProxyConfig) -> Result<DispatchPlan, String> {
+    let inbound_format = Some(InboundApiFormat::OpenaiResponses);
+    if let Some(selected) = choose_provider_by_priority(
+        config,
+        inbound_format,
+        &[PROVIDER_RESPONSES, PROVIDER_CODEX],
+    ) {
+        return Ok(match selected {
+            PROVIDER_RESPONSES => base_plan(PROVIDER_RESPONSES),
+            PROVIDER_CODEX => DispatchPlan {
+                provider: PROVIDER_CODEX,
+                outbound_path: Some(CODEX_RESPONSES_PATH),
+                request_transform: FormatTransform::ResponsesCompactToCodex,
+                response_transform: FormatTransform::CodexToResponses,
+            },
+            _ => base_plan(PROVIDER_RESPONSES),
+        });
+    }
+    Err(ERROR_NO_UPSTREAM.to_string())
 }
 
 fn resolve_chat_plan(config: &ProxyConfig) -> Result<DispatchPlan, String> {
@@ -526,6 +567,11 @@ fn resolve_dispatch_plan(config: &ProxyConfig, path: &str) -> Result<DispatchPla
 
 fn resolve_outbound_path(path: &str, plan: &DispatchPlan, meta: &RequestMeta) -> String {
     match (plan.outbound_path, plan.provider) {
+        (Some(CODEX_RESPONSES_PATH), PROVIDER_CODEX)
+            if openai::is_openai_responses_compact_path(path) =>
+        {
+            CODEX_RESPONSES_COMPACT_PATH.to_string()
+        }
         (Some(outbound_path), _) => outbound_path.to_string(),
         (None, _) if is_openai_compatible_models_path(path) => {
             path.replacen("/v1beta/openai/models", "/v1/models", 1)
@@ -597,7 +643,11 @@ fn build_retry_fallback_plan(path: &str, provider: &'static str) -> Option<Dispa
             PROVIDER_CODEX => Some(DispatchPlan {
                 provider: PROVIDER_CODEX,
                 outbound_path: Some(CODEX_RESPONSES_PATH),
-                request_transform: FormatTransform::ResponsesToCodex,
+                request_transform: if openai::is_openai_responses_compact_path(path) {
+                    FormatTransform::ResponsesCompactToCodex
+                } else {
+                    FormatTransform::ResponsesToCodex
+                },
                 response_transform: FormatTransform::CodexToResponses,
             }),
             _ => None,

--- a/crates/token_proxy_core/src/proxy/server.test.rs
+++ b/crates/token_proxy_core/src/proxy/server.test.rs
@@ -40,6 +40,7 @@ const FORMATS_MESSAGES: &[InboundApiFormat] = &[InboundApiFormat::AnthropicMessa
 const FORMATS_GEMINI: &[InboundApiFormat] = &[InboundApiFormat::Gemini];
 
 const FORMATS_KIRO_NATIVE: &[InboundApiFormat] = &[InboundApiFormat::AnthropicMessages];
+const RESPONSES_COMPACT_PATH: &str = "/v1/responses/compact";
 
 fn run_async<T>(future: impl std::future::Future<Output = T>) -> T {
     Runtime::new()
@@ -3385,6 +3386,67 @@ fn responses_fallback_requires_format_conversion_enabled() {
 }
 
 #[test]
+fn responses_compact_requires_responses_family_provider() {
+    let config = config_with_providers(&[(PROVIDER_CHAT, FORMATS_ALL)]);
+    let error = resolve_dispatch_plan(&config, RESPONSES_COMPACT_PATH)
+        .err()
+        .expect("should reject");
+    assert_eq!(error, "No available upstream configured.");
+}
+
+#[test]
+fn responses_compact_prefers_responses_provider_and_preserves_path() {
+    let config = config_with_upstreams(&[
+        (PROVIDER_CHAT, 10, "chat", FORMATS_ALL),
+        (PROVIDER_RESPONSES, 0, "responses", FORMATS_RESPONSES),
+    ]);
+    let plan = resolve_dispatch_plan(&config, RESPONSES_COMPACT_PATH).expect("should dispatch");
+    assert_eq!(plan.provider, PROVIDER_RESPONSES);
+    assert_eq!(plan.outbound_path, None);
+    assert_eq!(plan.request_transform, FormatTransform::None);
+    assert_eq!(plan.response_transform, FormatTransform::None);
+
+    let outbound_path = resolve_outbound_path(
+        RESPONSES_COMPACT_PATH,
+        &plan,
+        &RequestMeta {
+            stream: false,
+            original_model: Some("gpt-5.4".to_string()),
+            mapped_model: None,
+            reasoning_effort: None,
+            estimated_input_tokens: None,
+        },
+    );
+    assert_eq!(outbound_path, RESPONSES_COMPACT_PATH);
+}
+
+#[test]
+fn responses_compact_can_route_to_codex_and_preserve_compact_suffix() {
+    let config = config_with_providers(&[(PROVIDER_CODEX, FORMATS_RESPONSES)]);
+    let plan = resolve_dispatch_plan(&config, RESPONSES_COMPACT_PATH).expect("should dispatch");
+    assert_eq!(plan.provider, PROVIDER_CODEX);
+    assert_eq!(plan.outbound_path, Some(CODEX_RESPONSES_PATH));
+    assert_eq!(
+        plan.request_transform,
+        FormatTransform::ResponsesCompactToCodex
+    );
+    assert_eq!(plan.response_transform, FormatTransform::CodexToResponses);
+
+    let outbound_path = resolve_outbound_path(
+        RESPONSES_COMPACT_PATH,
+        &plan,
+        &RequestMeta {
+            stream: false,
+            original_model: Some("gpt-5.4".to_string()),
+            mapped_model: None,
+            reasoning_effort: None,
+            estimated_input_tokens: None,
+        },
+    );
+    assert_eq!(outbound_path, "/responses/compact");
+}
+
+#[test]
 fn responses_does_not_route_to_kiro() {
     let config = config_with_providers(&[(PROVIDER_KIRO, FORMATS_ALL)]);
     let error = resolve_dispatch_plan(&config, RESPONSES_PATH)
@@ -3430,6 +3492,23 @@ fn retry_fallback_plan_switches_responses_to_codex() {
     assert_eq!(plan.provider, PROVIDER_CODEX);
     assert_eq!(plan.outbound_path, Some(CODEX_RESPONSES_PATH));
     assert_eq!(plan.request_transform, FormatTransform::ResponsesToCodex);
+    assert_eq!(plan.response_transform, FormatTransform::CodexToResponses);
+}
+
+#[test]
+fn retry_fallback_plan_switches_compact_responses_to_codex() {
+    let config = config_with_providers(&[
+        (PROVIDER_RESPONSES, FORMATS_RESPONSES),
+        (PROVIDER_CODEX, FORMATS_RESPONSES),
+    ]);
+    let plan = resolve_retry_fallback_plan(&config, RESPONSES_COMPACT_PATH, PROVIDER_RESPONSES)
+        .expect("should fallback to codex");
+    assert_eq!(plan.provider, PROVIDER_CODEX);
+    assert_eq!(plan.outbound_path, Some(CODEX_RESPONSES_PATH));
+    assert_eq!(
+        plan.request_transform,
+        FormatTransform::ResponsesCompactToCodex
+    );
     assert_eq!(plan.response_transform, FormatTransform::CodexToResponses);
 }
 


### PR DESCRIPTION
## Summary
This PR submits the remaining local proxy changes that were still dirty in the working tree.

It adds explicit support for `/v1/responses/compact` across OpenAI-compatible routing, Codex request transformation, retry fallback planning, and streaming dispatch.

## What changed
- Add `/v1/responses/compact` path detection in the OpenAI path helpers.
- Add `ResponsesCompactToCodex` request transform.
- Strip `include`, `store`, and `stream` from compact requests before forwarding to Codex.
- Preserve `/responses/compact` on outbound Codex routing.
- Extend retry fallback and dispatch planning to handle compact responses explicitly.
- Add focused tests for compact routing and request normalization.

## Validation
- `cargo test --package token_proxy_core --lib responses_compact -- --nocapture`
