### PR TITLE
[codex] fix dashboard local proxy label

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -366,6 +366,7 @@
   "dashboard_table_time": "Time",
   "dashboard_table_path": "Path",
   "dashboard_table_provider": "Provider",
+  "dashboard_provider_local_proxy": "Local proxy",
   "dashboard_table_model": "Model",
   "dashboard_table_status": "Status",
   "dashboard_table_tokens": "Tokens",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -367,6 +367,7 @@
   "dashboard_table_time": "时间",
   "dashboard_table_path": "路径",
   "dashboard_table_provider": "Provider",
+  "dashboard_provider_local_proxy": "本地代理",
   "dashboard_table_model": "Model",
   "dashboard_table_status": "状态",
   "dashboard_table_tokens": "Tokens",

--- a/src/features/dashboard/RecentRequestsTable.test.tsx
+++ b/src/features/dashboard/RecentRequestsTable.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { RecentRequestsTable } from "@/features/dashboard/RecentRequestsTable";
 import { I18nProvider } from "@/lib/i18n";
 import { m } from "@/paraglide/messages.js";
+import { setLocale } from "@/paraglide/runtime.js";
 
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: ({ count }: { count: number }) => ({
@@ -30,6 +31,7 @@ describe("dashboard/RecentRequestsTable", () => {
 
   afterEach(() => {
     cleanup();
+    setLocale("en", { reload: false });
   });
 
   it("shows account id in provider column when request is bound to an account", () => {
@@ -143,5 +145,44 @@ describe("dashboard/RecentRequestsTable", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent("45.5K");
     expect(await screen.findByRole("tooltip")).toHaveTextContent("1.6K");
     expect(await screen.findByRole("tooltip")).toHaveTextContent("43.4K");
+  });
+
+  it("shows local proxy label for proxy local auth failures", async () => {
+    setLocale("zh", { reload: false });
+    const user = userEvent.setup();
+
+    render(
+      <I18nProvider>
+        <RecentRequestsTable
+          scrollKey="test"
+          items={[
+            {
+              id: 1,
+              tsMs: 100,
+              path: "/v1/responses",
+              provider: "proxy",
+              upstreamId: "local",
+              accountId: null,
+              model: null,
+              mappedModel: null,
+              stream: false,
+              status: 401,
+              totalTokens: null,
+              outputTokens: null,
+              cachedTokens: null,
+              latencyMs: 0,
+              upstreamRequestId: null,
+            },
+          ]}
+        />
+      </I18nProvider>,
+    );
+
+    const localProxyLabel = "本地代理";
+    expect(screen.getByText(localProxyLabel)).toBeInTheDocument();
+    expect(screen.queryByText("local · proxy")).toBeNull();
+
+    await user.hover(screen.getByText(localProxyLabel));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(localProxyLabel);
   });
 });

--- a/src/features/dashboard/format.test.ts
+++ b/src/features/dashboard/format.test.ts
@@ -7,6 +7,7 @@ import {
   formatDashboardTimestamp,
   formatInteger,
 } from "@/features/dashboard/format";
+import { setLocale } from "@/paraglide/runtime.js";
 
 describe("dashboard/format", () => {
   it("formats integers with thousand separators", () => {
@@ -58,5 +59,10 @@ describe("dashboard/format", () => {
     expect(formatDashboardProviderLabel("fallback", "anthropic", null)).toBe(
       "fallback · anthropic"
     );
+  });
+
+  it("uses a dedicated label for local proxy request failures", () => {
+    setLocale("en", { reload: false });
+    expect(formatDashboardProviderLabel("local", "proxy", null)).toBe("Local proxy");
   });
 });

--- a/src/features/dashboard/format.ts
+++ b/src/features/dashboard/format.ts
@@ -1,3 +1,5 @@
+import { m } from "@/paraglide/messages.js";
+
 const DASHBOARD_TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   dateStyle: "short",
   timeStyle: "medium",
@@ -14,6 +16,20 @@ function normalizeProviderPart(value: string | null | undefined) {
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isLocalProxyRequest(
+  upstreamId: string,
+  provider: string,
+  accountId: string | null | undefined,
+) {
+  if (accountId?.trim()) {
+    return false;
+  }
+  return (
+    normalizeProviderPart(upstreamId) === "local" &&
+    normalizeProviderPart(provider) === "proxy"
+  );
 }
 
 function containsProviderPart(value: string | null | undefined, provider: string) {
@@ -43,6 +59,10 @@ export function formatDashboardProviderLabel(
   provider: string,
   accountId: string | null | undefined,
 ) {
+  if (isLocalProxyRequest(upstreamId, provider, accountId)) {
+    return m.dashboard_provider_local_proxy();
+  }
+
   const trimmedProvider = provider.trim();
   const shouldHideProvider =
     trimmedProvider.length > 0 &&

--- a/src/features/logs/LogsPanel.test.tsx
+++ b/src/features/logs/LogsPanel.test.tsx
@@ -273,7 +273,7 @@ describe("logs/LogsPanel", () => {
       expect(readRequestLogDetailMock).toHaveBeenCalledWith(1);
     });
 
-    const providerValues = await screen.findAllByText("alpha · codex · codex-a.json");
+    const providerValues = await screen.findAllByText("alpha · codex-a.json");
     expect(providerValues.length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
## Summary
- show a dedicated local proxy label instead of rendering local · proxy
- add i18n copy for the dedicated local proxy label
- update dashboard/logs tests to match the corrected display semantics

## Testing
- pnpm exec vitest run src/features/dashboard/format.test.ts
- pnpm exec vitest run src/features/dashboard/RecentRequestsTable.test.tsx
- pnpm exec vitest run src/features/logs/LogsPanel.test.tsx
