### PR TITLE
fix: parse request metadata for large JSON bodies

### DIFF
--- a/crates/token_proxy_core/src/proxy/server_helpers.rs
+++ b/crates/token_proxy_core/src/proxy/server_helpers.rs
@@ -17,7 +17,9 @@ use super::{
 
 const ANTHROPIC_MESSAGES_PREFIX: &str = "/v1/messages";
 const ANTHROPIC_COMPLETE_PATH: &str = "/v1/complete";
-const REQUEST_META_LIMIT_BYTES: usize = 2 * 1024 * 1024;
+// Keep request meta parsing aligned with the default max_request_body_bytes (20 MiB)
+// so large responses/codex requests still expose `stream` and `model`.
+const REQUEST_META_LIMIT_BYTES: usize = 20 * 1024 * 1024;
 // Format conversion needs the full JSON body; allow up to the default max_request_body_bytes (20 MiB).
 const REQUEST_TRANSFORM_LIMIT_BYTES: usize = 20 * 1024 * 1024;
 const DEBUG_BODY_LOG_LIMIT_BYTES: usize = usize::MAX;

--- a/crates/token_proxy_core/src/proxy/server_helpers.test.rs
+++ b/crates/token_proxy_core/src/proxy/server_helpers.test.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use axum::body::Bytes;
+use axum::body::{Body, Bytes};
 
 #[test]
 fn force_openai_chat_stream_usage_inserts_stream_options_include_usage() {
@@ -56,6 +56,25 @@ fn gemini_meta_treats_generate_content_alt_sse_as_stream() {
         .await;
         assert!(meta.stream);
         assert_eq!(meta.original_model.as_deref(), Some("gemini-1.5-flash"));
+    });
+}
+
+#[test]
+fn meta_parses_large_request_body_for_stream_and_model() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let padding = "x".repeat((2 * 1024 * 1024) + 128);
+        let request = format!(
+            r#"{{"model":"gpt-5.4","stream":true,"input":"hello","padding":"{padding}"}}"#
+        );
+        let body = ReplayableBody::from_body(Body::from(request))
+            .await
+            .expect("body");
+
+        let meta = parse_request_meta_best_effort(RESPONSES_PATH, &body).await;
+
+        assert!(meta.stream);
+        assert_eq!(meta.original_model.as_deref(), Some("gpt-5.4"));
     });
 }
 


### PR DESCRIPTION
## Summary
- raise `REQUEST_META_LIMIT_BYTES` from 2 MiB to 20 MiB so request metadata parsing stays aligned with the default max request body size
- add a regression test covering a request body just over 2 MiB that still needs to preserve `stream` and `model`

## Test Plan
- `cargo test -p token_proxy_core meta_parses_large_request_body_for_stream_and_model -- --nocapture`
- `cargo test -p token_proxy_core proxy::server_helpers::tests -- --nocapture`
- `cargo test -p token_proxy_core` *(still shows the pre-existing upstream failure in `messages_request_falls_back_to_next_kiro_upstream_after_all_kiro_accounts_fail` on both this branch and `origin/main`)*