### PR TITLE
fix: resolve draft release for updater json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,6 +323,21 @@ jobs:
               }
             }
 
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const existingDraft = releases.find((release) => release.tag_name === tag);
+            if (existingDraft) {
+              core.setOutput("release_draft", String(Boolean(existingDraft.draft)));
+              core.setOutput("release_id", String(existingDraft.id));
+              core.info(
+                `Resolved existing release ${tag} from release list (#${existingDraft.id}, draft=${Boolean(existingDraft.draft)}).`
+              );
+              return;
+            }
+
             const { data } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -443,6 +458,7 @@ jobs:
       - name: Generate and upload latest.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ needs.stable_release_bootstrap.outputs.release_id }}
           TAG_NAME: ${{ needs.stable_tag.outputs.tag }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: node scripts/generate-updater-json.mjs

--- a/scripts/generate-updater-json.mjs
+++ b/scripts/generate-updater-json.mjs
@@ -177,13 +177,20 @@ function buildUpdaterRules(version) {
 async function main() {
   const token = requireEnv("GITHUB_TOKEN");
   const tagName = requireEnv("TAG_NAME");
+  const releaseId = process.env.RELEASE_ID?.trim() || "";
   const { owner, repo } = parseOwnerRepo(requireEnv("GITHUB_REPOSITORY"));
 
   const apiBase = process.env.GITHUB_API_URL || "https://api.github.com";
-  const release = await githubRequestJson(
-    `${apiBase}/repos/${owner}/${repo}/releases/tags/${encodeURIComponent(tagName)}`,
-    token
-  );
+  const release =
+    releaseId !== ""
+      ? await githubRequestJson(
+          `${apiBase}/repos/${owner}/${repo}/releases/${encodeURIComponent(releaseId)}`,
+          token
+        )
+      : await githubRequestJson(
+          `${apiBase}/repos/${owner}/${repo}/releases/tags/${encodeURIComponent(tagName)}`,
+          token
+        );
 
   const version = stripTagPrefix(release.tag_name || tagName);
   const notes = typeof release.body === "string" ? release.body : "";


### PR DESCRIPTION
## Summary
- use bootstrap release id when generating updater latest.json so draft releases do not 404 on tag lookup
- let release bootstrap fall back to existing draft releases when tag lookup is unavailable
- keep current v0.1.72 draft release recoverable for republish

## Testing
- node --check scripts/generate-updater-json.mjs
- git diff --check