### PR TITLE
fix: fail over codex accounts after retryable 2xx outcomes

### DIFF
--- a/crates/token_proxy_core/src/proxy/server/tests.rs
+++ b/crates/token_proxy_core/src/proxy/server/tests.rs
@@ -191,6 +191,10 @@ struct MockAuthSwitchState {
     primary_status: StatusCode,
 }
 
+struct MockCodexEmptyChatSwitchState {
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+}
+
 #[derive(Clone)]
 struct MockKiroAuthSwitchState {
     requests: Arc<Mutex<Vec<RecordedRequest>>>,
@@ -473,6 +477,89 @@ async fn auth_switch_upstream_handler(
         .into_response()
 }
 
+async fn codex_empty_chat_switch_upstream_handler(
+    State(state): State<Arc<MockCodexEmptyChatSwitchState>>,
+    headers: HeaderMap,
+    uri: Uri,
+    body: Body,
+) -> axum::response::Response {
+    let bytes = to_bytes(body, usize::MAX).await.expect("read mock body");
+    let json_body = serde_json::from_slice::<Value>(&bytes).expect("mock request json");
+    let authorization = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let chatgpt_account_id = headers
+        .get("chatgpt-account-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+
+    state
+        .requests
+        .lock()
+        .expect("requests lock")
+        .push(RecordedRequest {
+            path: uri.path().to_string(),
+            body: json_body,
+            authorization: authorization.clone(),
+            chatgpt_account_id: chatgpt_account_id.clone(),
+        });
+
+    let body = match authorization.as_deref() {
+        Some("Bearer codex-access-a") => json!({
+            "id": "resp_codex_empty_chat",
+            "object": "response",
+            "created_at": 123,
+            "model": "gpt-5-codex",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_empty",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": []
+                }
+            ],
+            "usage": { "input_tokens": 1, "output_tokens": 0, "total_tokens": 1 }
+        }),
+        Some("Bearer codex-access-b") => json!({
+            "id": "resp_codex_failover_after_empty",
+            "object": "response",
+            "created_at": 123,
+            "model": "gpt-5-codex",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_ok",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        { "type": "output_text", "text": "from codex failover after empty chat" }
+                    ]
+                }
+            ],
+            "usage": { "input_tokens": 1, "output_tokens": 5, "total_tokens": 6 }
+        }),
+        _ => json!({
+            "error": {
+                "message": "unexpected account",
+                "type": "invalid_request_error",
+                "code": "token_invalidated",
+                "param": null
+            }
+        }),
+    };
+
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        body.to_string(),
+    )
+        .into_response()
+}
+
 async fn spawn_auth_switch_mock_upstream() -> MockUpstream {
     let requests = Arc::new(Mutex::new(Vec::new()));
     let state = Arc::new(MockAuthSwitchState {
@@ -490,6 +577,30 @@ async fn spawn_auth_switch_mock_upstream() -> MockUpstream {
         axum::serve(listener, app)
             .await
             .expect("auth switch mock upstream server should run");
+    });
+    MockUpstream {
+        base_url: format!("http://{addr}"),
+        requests,
+        task,
+    }
+}
+
+async fn spawn_codex_empty_chat_switch_mock_upstream() -> MockUpstream {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let state = Arc::new(MockCodexEmptyChatSwitchState {
+        requests: requests.clone(),
+    });
+    let app = Router::new()
+        .route("/{*path}", any(codex_empty_chat_switch_upstream_handler))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind empty chat switch mock upstream");
+    let addr: SocketAddr = listener.local_addr().expect("mock local addr");
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("empty chat switch mock upstream server should run");
     });
     MockUpstream {
         base_url: format!("http://{addr}"),
@@ -1376,6 +1487,35 @@ async fn send_responses_request(state: ProxyStateHandle) -> (StatusCode, Value) 
     (status, json)
 }
 
+async fn send_chat_request(state: ProxyStateHandle) -> (StatusCode, Value) {
+    let response = proxy_request(
+        State(state),
+        Method::POST,
+        Uri::from_static("/v1/chat/completions"),
+        axum::http::HeaderMap::new(),
+        Body::from(
+            json!({
+                "model": "gpt-5",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "hi"
+                    }
+                ]
+            })
+            .to_string(),
+        ),
+    )
+    .await;
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("proxy response bytes");
+    let json = serde_json::from_slice(&body).expect("proxy response json");
+    (status, json)
+}
+
 async fn send_messages_request(state: ProxyStateHandle) -> (StatusCode, Value) {
     let response = proxy_request(
         State(state),
@@ -1972,6 +2112,69 @@ fn responses_request_failovers_to_next_codex_account_after_proxy_error() {
             Some("Bearer codex-access-b")
         );
         assert_eq!(requests[0].chatgpt_account_id.as_deref(), Some("chatgpt-b"));
+    });
+}
+
+#[test]
+fn chat_request_failovers_to_next_codex_account_after_empty_2xx_response() {
+    run_async(async {
+        let codex = spawn_codex_empty_chat_switch_mock_upstream().await;
+
+        let mut config = config_with_runtime_upstreams(&[(
+            PROVIDER_CODEX,
+            0,
+            "codex-auto-empty-chat-failover",
+            codex.base_url.as_str(),
+            FORMATS_CHAT,
+        )]);
+        let provider_upstreams = config
+            .upstreams
+            .get_mut(PROVIDER_CODEX)
+            .expect("codex upstreams");
+        provider_upstreams.groups[0].items[0].codex_account_id = None;
+
+        let data_dir = next_test_data_dir("chat_codex_account_empty_response_failover");
+        let state = build_test_state_handle(config, data_dir.clone()).await;
+        let expires_at = (OffsetDateTime::now_utc() + TimeDuration::days(1))
+            .format(&time::format_description::well_known::Rfc3339)
+            .expect("format expires_at");
+        seed_codex_account(
+            &state,
+            "codex-a.json",
+            "codex-access-a",
+            "chatgpt-a",
+            &expires_at,
+        )
+        .await;
+        seed_codex_account(
+            &state,
+            "codex-b.json",
+            "codex-access-b",
+            "chatgpt-b",
+            &expires_at,
+        )
+        .await;
+
+        let (status, json) = send_chat_request(state).await;
+        let requests = codex.requests();
+
+        codex.abort();
+        let _ = std::fs::remove_dir_all(&data_dir);
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            json["choices"][0]["message"]["content"].as_str(),
+            Some("from codex failover after empty chat")
+        );
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0].authorization.as_deref(),
+            Some("Bearer codex-access-a")
+        );
+        assert_eq!(
+            requests[1].authorization.as_deref(),
+            Some("Bearer codex-access-b")
+        );
     });
 }
 

--- a/crates/token_proxy_core/src/proxy/upstream/retry.rs
+++ b/crates/token_proxy_core/src/proxy/upstream/retry.rs
@@ -144,7 +144,8 @@ pub(super) async fn retry_with_next_codex_account(
     request_detail: Option<RequestDetailSnapshot>,
     first: Result<UpstreamAttempt, UpstreamAttemptFailure>,
 ) -> CodexFailoverResult {
-    let Some(first_selected_account_id) = failover_selected_account_id(provider, upstream, &first)
+    let Some(first_selected_account_id) =
+        codex_failover_selected_account_id(provider, upstream, &first)
     else {
         return match first {
             Ok(attempt) => CodexFailoverResult::Pending(attempt),
@@ -153,21 +154,25 @@ pub(super) async fn retry_with_next_codex_account(
     };
 
     let mut excluded_account_ids = vec![first_selected_account_id];
-    let mut last_outcome = Some(
-        finalize_codex_failover_attempt(
+    let mut current_upstream = upstream.clone();
+    let mut current_attempt = first;
+
+    loop {
+        let outcome = finalize_codex_failover_attempt(
             state,
             provider,
-            upstream,
+            &current_upstream,
             inbound_path,
             client_gemini_api_key,
             response_transform,
             request_detail.clone(),
-            first,
+            current_attempt,
         )
-        .await,
-    );
+        .await;
+        if !should_failover_codex_outcome(&outcome) {
+            return CodexFailoverResult::Resolved(outcome);
+        }
 
-    loop {
         let ordered_account_ids = state
             .codex_accounts
             .list_accounts()
@@ -191,17 +196,7 @@ pub(super) async fn retry_with_next_codex_account(
             .await
         {
             Ok(Some((account_id, _))) => account_id,
-            Ok(None) => match last_outcome {
-                Some(outcome) => return CodexFailoverResult::Resolved(outcome),
-                None => {
-                    return CodexFailoverResult::Resolved(AttemptOutcome::Fatal(
-                        http::error_response(
-                            StatusCode::BAD_GATEWAY,
-                            "No available Codex account remained after failover.",
-                        ),
-                    ));
-                }
-            },
+            Ok(None) => return CodexFailoverResult::Resolved(outcome),
             Err(err) => {
                 return CodexFailoverResult::Resolved(AttemptOutcome::Fatal(http::error_response(
                     StatusCode::UNAUTHORIZED,
@@ -210,13 +205,14 @@ pub(super) async fn retry_with_next_codex_account(
             }
         };
 
-        let mut retry_upstream = upstream.clone();
-        retry_upstream.codex_account_id = Some(next_account_id.clone());
-        let retry = attempt::attempt_send(
+        excluded_account_ids.push(next_account_id.clone());
+        current_upstream = upstream.clone();
+        current_upstream.codex_account_id = Some(next_account_id);
+        current_attempt = attempt::attempt_send(
             state,
             method.clone(),
             provider,
-            &retry_upstream,
+            &current_upstream,
             inbound_path,
             upstream_path_with_query,
             headers,
@@ -226,40 +222,6 @@ pub(super) async fn retry_with_next_codex_account(
             request_detail.as_ref(),
         )
         .await;
-        excluded_account_ids.push(next_account_id);
-
-        let should_retry_again = failover_selected_account_id(provider, upstream, &retry).is_some();
-        if !should_retry_again {
-            return match retry {
-                Ok(attempt) => CodexFailoverResult::Resolved(
-                    finalize_attempt(
-                        state,
-                        provider,
-                        &retry_upstream,
-                        inbound_path,
-                        client_gemini_api_key,
-                        response_transform,
-                        request_detail,
-                        attempt,
-                    )
-                    .await,
-                ),
-                Err(failure) => CodexFailoverResult::Resolved(failure.outcome),
-            };
-        }
-        last_outcome = Some(
-            finalize_codex_failover_attempt(
-                state,
-                provider,
-                &retry_upstream,
-                inbound_path,
-                client_gemini_api_key,
-                response_transform,
-                request_detail.clone(),
-                retry,
-            )
-            .await,
-        );
     }
 }
 
@@ -291,7 +253,7 @@ async fn finalize_codex_failover_attempt(
     }
 }
 
-fn failover_selected_account_id(
+fn codex_failover_selected_account_id(
     provider: &str,
     upstream: &UpstreamRuntime,
     attempt: &Result<UpstreamAttempt, UpstreamAttemptFailure>,
@@ -307,16 +269,17 @@ fn failover_selected_account_id(
     }
 
     match attempt {
-        Ok(attempt) if should_failover_codex_account(provider, &attempt.response) => {
-            attempt.selected_account_id.clone()
-        }
+        Ok(attempt) => attempt.selected_account_id.clone(),
         Err(failure) => failure.selected_account_id.clone(),
-        _ => None,
     }
 }
 
-fn should_failover_codex_account(provider: &str, response: &reqwest::Response) -> bool {
-    provider == "codex" && !response.status().is_success()
+fn should_failover_codex_outcome(outcome: &AttemptOutcome) -> bool {
+    match outcome {
+        AttemptOutcome::Success(response) => !response.status().is_success(),
+        AttemptOutcome::Retryable { .. } => true,
+        AttemptOutcome::Fatal(_) | AttemptOutcome::SkippedAuth => false,
+    }
 }
 
 fn schedule_account_quota_refresh(


### PR DESCRIPTION
## Summary
This change fixes unpinned Codex account failover so account switching is decided from the final proxy `AttemptOutcome`, not only the first raw upstream HTTP status.

Previously, the auto-selected Codex account path would switch to the next account when the initial send failed or when the raw upstream response was non-2xx, but it stopped account failover as soon as the upstream returned a raw 2xx response. That meant retryable "fake success" cases discovered later in proxy post-processing, such as an empty chat completion after Codex-to-chat transformation, were returned as a final 502 instead of continuing to the next available Codex account.

This PR makes the unpinned Codex account pool behave like the intended account-pool policy:
- continue to the next account for `Success(non-2xx)`
- continue to the next account for `Retryable`
- stop for `Fatal` and `SkippedAuth`

## Root Cause
The old Codex failover path in `retry_with_next_codex_account(...)` decided whether to advance to the next account before `finalize_attempt(...)` ran. As a result, it only had access to the raw `reqwest::Response` and could not see retryable outcomes that are produced later by proxy response handling.

## Fix
The failover loop now finalizes each attempted Codex account into a real `AttemptOutcome` first, then decides whether to continue account failover from that final outcome. This keeps upstream ordering unchanged and only changes the semantics inside the unpinned Codex account pool.

A regression test was added for the missing case: the first Codex account returns HTTP 200 but transforms into an empty chat completion, and the proxy must fail over to the next Codex account instead of returning 502 immediately.

## Validation
- `cargo test -p token_proxy_core chat_request_failovers_to_next_codex_account_after_empty_2xx_response -- --nocapture`
- `cargo test -p token_proxy_core codex_account -- --nocapture`
- `cargo test -p token_proxy_core messages_request_failovers_to_next_kiro_account_before_next_upstream -- --nocapture`
- `cargo fmt --all --check`
