### PR TITLE
fix: decouple logs refresh from model discovery

### DIFF
--- a/src/features/dashboard/DashboardPanel.tsx
+++ b/src/features/dashboard/DashboardPanel.tsx
@@ -26,7 +26,7 @@ export function DashboardPanel() {
     onRangeChange,
     onUpstreamChange,
     onAccountChange,
-  } = useDashboardSnapshot()
+  } = useDashboardSnapshot({ refreshModelDiscoveryOnRefresh: true })
 
   const isLoading = status === "loading"
 

--- a/src/features/dashboard/snapshot.test.tsx
+++ b/src/features/dashboard/snapshot.test.tsx
@@ -89,7 +89,7 @@ function HookHarness() {
     onAccountChange,
     refresh,
   } =
-    useDashboardSnapshot()
+    useDashboardSnapshot({ refreshModelDiscoveryOnRefresh: true })
 
   return (
     <div>

--- a/src/features/dashboard/snapshot.tsx
+++ b/src/features/dashboard/snapshot.tsx
@@ -40,6 +40,10 @@ const PUBLIC_ACCOUNT_VALUE = "__public_account__"
 
 type DashboardStatus = "idle" | "loading" | "error"
 
+type UseDashboardSnapshotOptions = {
+  refreshModelDiscoveryOnRefresh?: boolean
+}
+
 function hasUpstreamOption(
   upstreams: DashboardUpstreamOption[],
   upstreamId: string
@@ -88,7 +92,9 @@ function usePagination(totalRequests: number) {
   }
 }
 
-export function useDashboardSnapshot() {
+export function useDashboardSnapshot({
+  refreshModelDiscoveryOnRefresh = false,
+}: UseDashboardSnapshotOptions = {}) {
   const [rangePreset, setRangePreset] = useState<DashboardTimeRange>("today")
   const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null)
   const [selectedUpstreamId, setSelectedUpstreamId] = useState<string | null>(null)
@@ -201,16 +207,18 @@ export function useDashboardSnapshot() {
   const refresh = useCallback(() => {
     markLoading()
     void (async () => {
-      try {
-        await refreshDashboardModelDiscovery()
-      } catch (error) {
-        setStatus("error")
-        setStatusMessage(parseError(error))
-        return
+      if (refreshModelDiscoveryOnRefresh) {
+        try {
+          await refreshDashboardModelDiscovery()
+        } catch (error) {
+          setStatus("error")
+          setStatusMessage(parseError(error))
+          return
+        }
       }
       await loadSnapshot()
     })()
-  }, [loadSnapshot, markLoading])
+  }, [loadSnapshot, markLoading, refreshModelDiscoveryOnRefresh])
 
   return {
     snapshot,

--- a/src/features/logs/LogsPanel.test.tsx
+++ b/src/features/logs/LogsPanel.test.tsx
@@ -36,11 +36,13 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 const {
   readDashboardSnapshotMock,
+  refreshDashboardModelDiscoveryMock,
   readRequestDetailCaptureMock,
   setRequestDetailCaptureMock,
   readRequestLogDetailMock,
 } = vi.hoisted(() => ({
   readDashboardSnapshotMock: vi.fn(),
+  refreshDashboardModelDiscoveryMock: vi.fn(),
   readRequestDetailCaptureMock: vi.fn(),
   setRequestDetailCaptureMock: vi.fn(),
   readRequestLogDetailMock: vi.fn(),
@@ -48,6 +50,7 @@ const {
 
 vi.mock("@/features/dashboard/api", () => ({
   readDashboardSnapshot: readDashboardSnapshotMock,
+  refreshDashboardModelDiscovery: refreshDashboardModelDiscoveryMock,
 }));
 
 vi.mock("@/features/logs/api", () => ({
@@ -71,10 +74,12 @@ describe("logs/LogsPanel", () => {
 
   beforeEach(() => {
     readDashboardSnapshotMock.mockReset();
+    refreshDashboardModelDiscoveryMock.mockReset();
     readRequestDetailCaptureMock.mockReset();
     setRequestDetailCaptureMock.mockReset();
     readRequestLogDetailMock.mockReset();
 
+    refreshDashboardModelDiscoveryMock.mockResolvedValue(undefined);
     readRequestDetailCaptureMock.mockResolvedValue({
       enabled: false,
       expiresAtMs: null,
@@ -389,6 +394,24 @@ describe("logs/LogsPanel", () => {
         publicOnly: false,
       }
     );
+  });
+
+  it("refreshes logs without refreshing dashboard model discovery", async () => {
+    const user = userEvent.setup();
+
+    renderPanel();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("logs-items")).toHaveTextContent("alpha · openai · codex-a.json");
+    });
+    expect(readDashboardSnapshotMock).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: m.common_refresh() }));
+
+    await waitFor(() => {
+      expect(readDashboardSnapshotMock).toHaveBeenCalledTimes(2);
+    });
+    expect(refreshDashboardModelDiscoveryMock).not.toHaveBeenCalled();
   });
 
   it("narrows logs again after selecting account under chosen upstream", async () => {


### PR DESCRIPTION
## Summary
- keep model discovery refresh scoped to Dashboard only
- make useDashboardSnapshot refresh model discovery only when explicitly enabled
- add LogsPanel regression coverage so logs refresh never calls model discovery

## Cause
LogsPanel reused the dashboard snapshot hook, whose refresh path awaited refreshDashboardModelDiscovery before reloading data. A slow /models probe could keep the logs page refresh button spinning even though log queries were fast.

## Validation
- pnpm test:run --reporter=dot
- pnpm exec tsc --noEmit --pretty false
- pnpm run build
- rtk cargo test -p token_proxy_core
- cargo check --manifest-path src-tauri/Cargo.toml
- rtk git diff --check