### PR TITLE
fix: retry empty airouter chat sse

### DIFF
--- a/crates/token_proxy_core/src/proxy/response/dispatch/buffered.rs
+++ b/crates/token_proxy_core/src/proxy/response/dispatch/buffered.rs
@@ -198,6 +198,7 @@ struct ChatCompletionBuffer {
     finish_reason: Option<Value>,
     usage: Option<Value>,
     saw_chunk: bool,
+    saw_choice: bool,
 }
 
 impl ChatCompletionBuffer {
@@ -208,9 +209,6 @@ impl ChatCompletionBuffer {
             return;
         }
 
-        let Some(choice) = choices.and_then(|items| items.first()) else {
-            return;
-        };
         self.saw_chunk = true;
         self.id = self
             .id
@@ -227,6 +225,10 @@ impl ChatCompletionBuffer {
                 .map(str::to_string)
         });
         self.usage = value.get("usage").filter(|usage| !usage.is_null()).cloned();
+        let Some(choice) = choices.and_then(|items| items.first()) else {
+            return;
+        };
+        self.saw_choice = true;
         if let Some(reason) = choice
             .get("finish_reason")
             .filter(|reason| !reason.is_null())
@@ -262,7 +264,13 @@ impl ChatCompletionBuffer {
         choice.insert("message".to_string(), Value::Object(message));
         choice.insert(
             "finish_reason".to_string(),
-            self.finish_reason.unwrap_or(Value::Null),
+            self.finish_reason.unwrap_or_else(|| {
+                if self.saw_choice {
+                    Value::Null
+                } else {
+                    json!("stop")
+                }
+            }),
         );
 
         let mut output = Map::new();

--- a/crates/token_proxy_core/src/proxy/response/dispatch/buffered.test.rs
+++ b/crates/token_proxy_core/src/proxy/response/dispatch/buffered.test.rs
@@ -77,6 +77,32 @@ fn buffer_event_stream_response_converts_chat_completion_chunks_to_json() {
 }
 
 #[test]
+fn buffer_event_stream_response_converts_empty_choices_chunk_to_empty_stop() {
+    let sse = Bytes::from(
+        [
+            "data: {\"id\":\"\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"gpt-5.5\",\"system_fingerprint\":\"\",\"choices\":[],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":0,\"total_tokens\":12}}\n\n",
+            "data: [DONE]\n\n",
+        ]
+        .concat(),
+    );
+
+    let output = buffer_event_stream_response(&sse).expect("buffer SSE");
+    let value: serde_json::Value = serde_json::from_slice(&output).expect("json");
+
+    assert_eq!(value["object"], json!("chat.completion"));
+    assert_eq!(value["model"], json!("gpt-5.5"));
+    assert_eq!(value["choices"][0]["message"]["role"], json!("assistant"));
+    assert_eq!(value["choices"][0]["message"]["content"], json!(""));
+    assert_eq!(value["choices"][0]["finish_reason"], json!("stop"));
+    assert_eq!(value["usage"]["total_tokens"], json!(12));
+    assert_eq!(
+        empty_chat_completion_retry_message(&output, &test_context(), FormatTransform::None)
+            .as_deref(),
+        Some("Upstream returned empty chat completion content for stop response.")
+    );
+}
+
+#[test]
 fn buffer_event_stream_response_returns_completed_responses_object() {
     let completed = json!({
         "type": "response.completed",

--- a/crates/token_proxy_core/src/proxy/server/tests.rs
+++ b/crates/token_proxy_core/src/proxy/server/tests.rs
@@ -2306,6 +2306,72 @@ fn chat_request_failovers_to_next_codex_account_after_empty_2xx_response() {
 }
 
 #[test]
+fn chat_request_retries_empty_choices_event_stream_on_responses_provider() {
+    run_async(async {
+        let primary = spawn_mock_raw_upstream(
+            StatusCode::OK,
+            Bytes::from(
+                "data: {\"id\":\"\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"gpt-5.5\",\"system_fingerprint\":\"\",\"choices\":[],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":0,\"total_tokens\":12}}\n\n\
+data: [DONE]\n\n",
+            ),
+            "text/event-stream",
+        )
+        .await;
+        let fallback = spawn_mock_raw_upstream(
+            StatusCode::OK,
+            Bytes::from(
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"from responses fallback\"}\n\n\
+data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_fallback\",\"object\":\"response\",\"created_at\":123,\"model\":\"gpt-5\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"id\":\"msg_1\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"from responses fallback\"}]}],\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}}}\n\n\
+data: [DONE]\n\n",
+            ),
+            "text/event-stream",
+        )
+        .await;
+        let config = config_with_runtime_upstreams(&[
+            (
+                PROVIDER_CHAT,
+                10,
+                "airouter-chat-empty",
+                primary.base_url.as_str(),
+                FORMATS_CHAT,
+            ),
+            (
+                PROVIDER_RESPONSES,
+                5,
+                "airouter-responses-fallback",
+                fallback.base_url.as_str(),
+                FORMATS_RESPONSES,
+            ),
+        ]);
+        let data_dir = next_test_data_dir("chat_empty_choices_stream_responses_fallback");
+        let state = build_test_state_handle(config, data_dir.clone()).await;
+
+        let (status, json) = send_chat_request(state).await;
+        let primary_requests = primary.requests();
+        let fallback_requests = fallback.requests();
+
+        primary.abort();
+        fallback.abort();
+        let _ = std::fs::remove_dir_all(&data_dir);
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            json["choices"][0]["message"]["content"].as_str(),
+            Some("from responses fallback")
+        );
+        assert_eq!(primary_requests.len(), 1);
+        assert_eq!(primary_requests[0].path, "/v1/chat/completions");
+        assert_eq!(fallback_requests.len(), 1);
+        assert_eq!(fallback_requests[0].path, RESPONSES_PATH);
+        assert_eq!(fallback_requests[0].body["model"].as_str(), Some("gpt-5"));
+        assert_eq!(
+            fallback_requests[0].body["input"][0]["content"][0]["text"].as_str(),
+            Some("hi")
+        );
+    });
+}
+
+#[test]
 fn responses_request_cooldowns_same_codex_account_after_401() {
     run_async(async {
         let codex =


### PR DESCRIPTION
## Summary
- handle Airouter chat event-stream chunks with empty choices instead of treating them as unsupported payloads
- route empty stop chat completions through the existing retry/fallback path so Responses providers can recover
- add parser and server regression coverage for the gpt-5.5 empty choices SSE shape

## Tests
- cargo test -p token_proxy_core
- cargo fmt --all -- --check
- cargo check -p token_proxy_core
- cargo check --manifest-path src-tauri/Cargo.toml
- git diff --check