### PR TITLE
Fix logs table scrolling

### DIFF
--- a/src/features/dashboard/RecentRequestsTable.test.tsx
+++ b/src/features/dashboard/RecentRequestsTable.test.tsx
@@ -118,6 +118,58 @@ describe("dashboard/RecentRequestsTable", () => {
     expect(headerGrid?.className).not.toContain("1fr");
   });
 
+  it("allows horizontal overflow and lets the body height come from the viewport", () => {
+    render(
+      <I18nProvider>
+        <RecentRequestsTable
+          scrollKey="test"
+          items={[
+            {
+              id: 1,
+              tsMs: 100,
+              path: "/v1/chat/completions/with/a/very/long/path",
+              provider: "openai-response",
+              upstreamId: "alpha",
+              accountId: "codex-a.json",
+              model: "gpt-5.5-with-long-alias",
+              mappedModel: "openai/gpt-5.5",
+              stream: true,
+              status: 200,
+              totalTokens: 31,
+              outputTokens: 20,
+              cachedTokens: 5,
+              costNanoUsd: 1_210_000_000,
+              pricingVersion: "2026-05-02.openai-openrouter-v1",
+              pricingModel: "gpt-5.5",
+              pricingContextTier: "short",
+              latencyMs: 30,
+              upstreamRequestId: null,
+            },
+          ]}
+        />
+      </I18nProvider>,
+    );
+
+    const table = screen.getByTestId("recent-requests-table");
+    expect(table).toHaveClass("flex", "min-h-0", "flex-1", "overflow-hidden");
+
+    const horizontalScroller = table.querySelector(
+      '[data-slot="recent-requests-table-horizontal-scroll"]',
+    );
+    expect(horizontalScroller).toHaveClass("overflow-x-auto");
+    expect(horizontalScroller).not.toHaveClass("overflow-x-hidden");
+
+    const widthTrack = table.querySelector(
+      '[data-slot="recent-requests-table-width-track"]',
+    ) as HTMLElement | null;
+    expect(widthTrack?.style.minWidth).toBe("846px");
+
+    const body = table.querySelector('[data-slot="recent-requests-table-body"]');
+    expect(body).toHaveClass("min-h-0", "flex-1", "overflow-y-auto");
+    expect(body).not.toHaveClass("overflow-x-hidden");
+    expect((body as HTMLElement | null)?.style.height).toBe("");
+  });
+
   it("shows upstream response-header latency as the default latency value", async () => {
     const user = userEvent.setup();
 

--- a/src/features/dashboard/RecentRequestsTable.tsx
+++ b/src/features/dashboard/RecentRequestsTable.tsx
@@ -26,12 +26,12 @@ import { useI18n } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 import { m } from "@/paraglide/messages.js";
 
-const TABLE_HEIGHT_PX = 360;
 const ROW_HEIGHT_PX = 44;
 const OVERSCAN = 6;
 
 // 固定列宽避免虚拟列表行在状态、费用、延迟文本变化时抖动。
 const GRID_COLS = "grid-cols-[128px_140px_132px_104px_64px_82px_92px_104px]";
+const TABLE_MIN_WIDTH_PX = 846;
 const CELL_PLACEHOLDER = "—";
 const TOOLTIP_CONTENT_CLASS = "max-w-[560px] whitespace-pre-wrap break-words";
 type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
@@ -405,8 +405,8 @@ function RecentRequestsBody({
   return (
     <div
       ref={scrollRef}
-      className="overflow-y-auto overflow-x-hidden"
-      style={{ height: TABLE_HEIGHT_PX }}
+      data-slot="recent-requests-table-body"
+      className="min-h-0 flex-1 overflow-y-auto"
     >
       <div className="relative" style={{ height: rowVirtualizer.getTotalSize() }}>
         <RecentRequestsRows
@@ -438,14 +438,25 @@ export function RecentRequestsTable({ items, scrollKey, onSelectItem }: RecentRe
       <div
         data-slot="recent-requests-table"
         data-testid="recent-requests-table"
-        className="overflow-hidden rounded-lg border border-border/60"
+        className="flex min-h-0 flex-1 overflow-hidden rounded-lg border border-border/60"
       >
-        <RecentRequestsHeader table={table} />
-        <RecentRequestsBody
-          rows={table.getRowModel().rows}
-          scrollKey={scrollKey}
-          onSelectItem={onSelectItem}
-        />
+        <div
+          data-slot="recent-requests-table-horizontal-scroll"
+          className="min-h-0 flex-1 overflow-x-auto"
+        >
+          <div
+            data-slot="recent-requests-table-width-track"
+            className="flex h-full min-h-0 flex-col"
+            style={{ minWidth: TABLE_MIN_WIDTH_PX }}
+          >
+            <RecentRequestsHeader table={table} />
+            <RecentRequestsBody
+              rows={table.getRowModel().rows}
+              scrollKey={scrollKey}
+              onSelectItem={onSelectItem}
+            />
+          </div>
+        </div>
       </div>
     </TooltipProvider>
   );

--- a/src/features/dashboard/components/data-table.tsx
+++ b/src/features/dashboard/components/data-table.tsx
@@ -38,9 +38,9 @@ export function DataTable({
   onSelectItem,
 }: DataTableProps) {
   return (
-    <div className="px-4 lg:px-6">
-      <Card data-slot="dashboard-recent">
-        <CardHeader>
+    <div className="flex min-h-0 flex-1 flex-col px-4 lg:px-6">
+      <Card data-slot="dashboard-recent" className="min-h-0 flex-1 gap-4">
+        <CardHeader className="shrink-0">
           <CardTitle className="text-base">{m.dashboard_recent_title()}</CardTitle>
           <CardDescription>
             {m.dashboard_recent_desc({
@@ -77,7 +77,7 @@ export function DataTable({
             </p>
           </CardAction>
         </CardHeader>
-        <CardContent className="pt-0">
+        <CardContent className="flex min-h-0 flex-1 flex-col pt-0">
           {items.length ? (
             <RecentRequestsTable
               items={items}

--- a/src/features/logs/LogsPanel.test.tsx
+++ b/src/features/logs/LogsPanel.test.tsx
@@ -404,6 +404,17 @@ describe("logs/LogsPanel", () => {
     );
   });
 
+  it("lets the logs table area inherit the remaining app viewport height", async () => {
+    renderPanel();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("logs-items")).toHaveTextContent("alpha");
+    });
+
+    const panel = screen.getByTestId("logs-panel");
+    expect(panel).toHaveClass("flex", "min-h-0", "flex-1", "flex-col");
+  });
+
   it("refreshes logs without refreshing dashboard model discovery", async () => {
     const user = userEvent.setup();
 

--- a/src/features/logs/LogsPanel.tsx
+++ b/src/features/logs/LogsPanel.tsx
@@ -579,7 +579,7 @@ export function LogsPanel() {
   }, [detailOpen, selectedId]);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div data-testid="logs-panel" className="flex min-h-0 flex-1 flex-col gap-4">
       {status === "error" ? (
         <Alert variant="destructive" className="mx-4 lg:mx-6">
           <AlertCircle className="size-4" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- make logs table body inherit viewport height instead of fixed 360px
- add horizontal scroll track for wide request rows
- extend table/logs layout tests for x/y scrolling behavior

## Validation
- pnpm test:run --reporter=dot
- pnpm run build
- git diff --check