### PR TITLE
fix: retry transient capacity on same upstream

### DIFF
--- a/crates/token_proxy_core/src/proxy/response/dispatch/buffered.rs
+++ b/crates/token_proxy_core/src/proxy/response/dispatch/buffered.rs
@@ -122,12 +122,16 @@ pub(super) async fn build_buffered_response(
         response.extensions_mut().insert(RetryableStreamResponse {
             message,
             should_cooldown: false,
+            retry_same_upstream_once: false,
         });
         return response;
     }
 
     let mut entry = build_log_entry(&context, usage, response_error);
     let response_text = String::from_utf8_lossy(output.as_ref());
+    let is_capacity_retry_error =
+        !status.is_success() && is_capacity_retry_error(response_text.as_ref(), &response_text);
+    let capacity_retry_message = is_capacity_retry_error.then(|| response_text.to_string());
     attach_response_body(&mut entry, response_text.as_ref());
     log.clone().write_detached(entry);
 
@@ -148,6 +152,12 @@ pub(super) async fn build_buffered_response(
         response
             .extensions_mut()
             .insert(NonRetryableSemanticResponse);
+    } else if let Some(message) = capacity_retry_message {
+        response.extensions_mut().insert(RetryableStreamResponse {
+            message,
+            should_cooldown: false,
+            retry_same_upstream_once: true,
+        });
     }
     response
 }
@@ -886,6 +896,7 @@ async fn read_upstream_bytes(
             response.extensions_mut().insert(RetryableStreamResponse {
                 message,
                 should_cooldown: true,
+                retry_same_upstream_once: false,
             });
             return Err(response);
         }
@@ -927,6 +938,7 @@ async fn read_upstream_bytes(
                 response.extensions_mut().insert(RetryableStreamResponse {
                     message,
                     should_cooldown: true,
+                    retry_same_upstream_once: false,
                 });
             }
             return Err(response);
@@ -963,6 +975,7 @@ fn respond_codex_images_transform_error(
         response.extensions_mut().insert(RetryableStreamResponse {
             message: error_message,
             should_cooldown: false,
+            retry_same_upstream_once: false,
         });
     }
     response
@@ -1042,6 +1055,48 @@ fn is_context_window_error(response_error: Option<&str>, bytes: &Bytes) -> bool 
     }
     let Ok(value) = serde_json::from_slice::<Value>(bytes) else {
         return matches_text(String::from_utf8_lossy(bytes).as_ref());
+    };
+    for pointer in [
+        "/error/message",
+        "/response/error/message",
+        "/message",
+        "/error/code",
+        "/response/error/code",
+        "/code",
+    ] {
+        if value
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .is_some_and(matches_text)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+pub(super) fn is_capacity_retry_error(response_error: &str, body: &str) -> bool {
+    fn matches_text(text: &str) -> bool {
+        let lower = text.trim().to_ascii_lowercase();
+        if lower.is_empty() {
+            return false;
+        }
+        if lower.contains("selected model is at capacity") {
+            return true;
+        }
+        lower.contains("model")
+            && lower.contains("capacity")
+            && (lower.contains("try a different model")
+                || lower.contains("please try again")
+                || lower.contains("temporarily unavailable")
+                || lower.contains("at capacity"))
+    }
+
+    if matches_text(response_error) || matches_text(body) {
+        return true;
+    }
+    let Ok(value) = serde_json::from_str::<Value>(body) else {
+        return false;
     };
     for pointer in [
         "/error/message",

--- a/crates/token_proxy_core/src/proxy/response/dispatch/stream.rs
+++ b/crates/token_proxy_core/src/proxy/response/dispatch/stream.rs
@@ -29,6 +29,7 @@ use super::super::{
     responses_to_chat, streaming, upstream_stream, RetryableStreamResponse, PROVIDER_CODEX,
     PROVIDER_GEMINI, PROVIDER_OPENAI, PROVIDER_OPENAI_RESPONSES,
 };
+use super::buffered;
 
 type UpstreamBytesStream = futures_util::stream::BoxStream<
     'static,
@@ -972,6 +973,7 @@ fn stream_first_output_timeout_response(
     response.extensions_mut().insert(RetryableStreamResponse {
         message,
         should_cooldown: true,
+        retry_same_upstream_once: false,
     });
     response
 }
@@ -1015,9 +1017,11 @@ fn codex_prelude_retry_response(
         [error_chunk.as_ref(), b"data: [DONE]\n\n"].concat(),
     ));
     let mut response = http::build_response(status, headers.clone(), body);
+    let retry_same_upstream_once = buffered::is_capacity_retry_error(&message, &message);
     response.extensions_mut().insert(RetryableStreamResponse {
         message,
-        should_cooldown: true,
+        should_cooldown: !retry_same_upstream_once,
+        retry_same_upstream_once,
     });
     response
 }
@@ -1078,6 +1082,7 @@ fn stream_error_response(
         response.extensions_mut().insert(RetryableStreamResponse {
             message,
             should_cooldown: true,
+            retry_same_upstream_once: false,
         });
     }
     response

--- a/crates/token_proxy_core/src/proxy/response/mod.rs
+++ b/crates/token_proxy_core/src/proxy/response/mod.rs
@@ -32,6 +32,7 @@ const IMAGE_GENERATION_MIN_NO_DATA_TIMEOUT: Duration = Duration::from_secs(300);
 pub(super) struct RetryableStreamResponse {
     pub(super) message: String,
     pub(super) should_cooldown: bool,
+    pub(super) retry_same_upstream_once: bool,
 }
 
 #[derive(Clone)]

--- a/crates/token_proxy_core/src/proxy/server/tests.rs
+++ b/crates/token_proxy_core/src/proxy/server/tests.rs
@@ -169,6 +169,19 @@ struct MockRawUpstreamState {
 }
 
 #[derive(Clone)]
+struct MockRawSequenceResponse {
+    status: StatusCode,
+    body: Bytes,
+    content_type: String,
+}
+
+#[derive(Clone)]
+struct MockRawSequenceUpstreamState {
+    responses: Arc<Mutex<Vec<MockRawSequenceResponse>>>,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+}
+
+#[derive(Clone)]
 struct MockDelayedBodyUpstreamState {
     status: StatusCode,
     body: Bytes,
@@ -377,6 +390,86 @@ async fn spawn_mock_raw_upstream(
         axum::serve(listener, app)
             .await
             .expect("raw mock upstream server should run");
+    });
+    MockUpstream {
+        base_url: format!("http://{addr}"),
+        requests,
+        task,
+    }
+}
+
+async fn mock_raw_sequence_upstream_handler(
+    State(state): State<Arc<MockRawSequenceUpstreamState>>,
+    headers: HeaderMap,
+    uri: Uri,
+    body: Body,
+) -> axum::response::Response {
+    let bytes = to_bytes(body, usize::MAX).await.expect("read mock body");
+    let json_body = serde_json::from_slice::<Value>(&bytes).expect("mock request json");
+    state
+        .requests
+        .lock()
+        .expect("requests lock")
+        .push(RecordedRequest {
+            path: uri.path().to_string(),
+            body: json_body,
+            authorization: headers
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string),
+            chatgpt_account_id: headers
+                .get("chatgpt-account-id")
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string),
+        });
+    let response = {
+        let mut responses = state.responses.lock().expect("responses lock");
+        if responses.len() > 1 {
+            responses.remove(0)
+        } else {
+            responses
+                .first()
+                .cloned()
+                .expect("sequence mock must keep fallback response")
+        }
+    };
+    axum::response::Response::builder()
+        .status(response.status)
+        .header(
+            axum::http::header::CONTENT_TYPE,
+            response.content_type.as_str(),
+        )
+        .body(Body::from(response.body))
+        .expect("build raw sequence mock response")
+}
+
+async fn spawn_mock_raw_sequence_upstream(
+    responses: Vec<(StatusCode, Bytes, &'static str)>,
+) -> MockUpstream {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let responses = responses
+        .into_iter()
+        .map(|(status, body, content_type)| MockRawSequenceResponse {
+            status,
+            body,
+            content_type: content_type.to_string(),
+        })
+        .collect::<Vec<_>>();
+    let state = Arc::new(MockRawSequenceUpstreamState {
+        responses: Arc::new(Mutex::new(responses)),
+        requests: requests.clone(),
+    });
+    let app = Router::new()
+        .route("/{*path}", any(mock_raw_sequence_upstream_handler))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind raw sequence mock upstream");
+    let addr: SocketAddr = listener.local_addr().expect("mock local addr");
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("raw sequence mock upstream server should run");
     });
     MockUpstream {
         base_url: format!("http://{addr}"),
@@ -1922,6 +2015,87 @@ data: [DONE]\n\n",
     assert_eq!(fallback_requests[0].path, RESPONSES_PATH);
 }
 
+async fn assert_responses_request_retries_same_upstream_once_after_capacity_error() {
+    let primary = spawn_mock_raw_sequence_upstream(vec![
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            Bytes::from(
+                json!({
+                    "error": {
+                        "message": "Selected model is at capacity. Please try a different model."
+                    }
+                })
+                .to_string(),
+            ),
+            "application/json",
+        ),
+        (
+            StatusCode::OK,
+            Bytes::from(
+                json!({
+                    "id": "resp_after_capacity_retry",
+                    "object": "response",
+                    "created_at": 123,
+                    "model": "gpt-5",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "id": "msg_1",
+                            "status": "completed",
+                            "role": "assistant",
+                            "content": [
+                                { "type": "output_text", "text": "same upstream recovered" }
+                            ]
+                        }
+                    ],
+                    "usage": { "input_tokens": 1, "output_tokens": 2, "total_tokens": 3 }
+                })
+                .to_string(),
+            ),
+            "application/json",
+        ),
+    ])
+    .await;
+    let mut config = config_with_runtime_upstreams(&[(
+        PROVIDER_RESPONSES,
+        10,
+        "responses-capacity-primary",
+        primary.base_url.as_str(),
+        FORMATS_RESPONSES,
+    )]);
+    config.upstream_strategy = UpstreamStrategyRuntime {
+        order: UpstreamOrderStrategy::FillFirst,
+        dispatch: UpstreamDispatchRuntime::Serial,
+    };
+    let data_dir = next_test_data_dir("responses_capacity_same_upstream_retry");
+    let state = build_test_state_handle(config, data_dir.clone()).await;
+
+    let (status, json) = send_responses_request(state).await;
+    let primary_requests = primary.requests();
+
+    primary.abort();
+    let _ = std::fs::remove_dir_all(&data_dir);
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        json["output"][0]["content"][0]["text"].as_str(),
+        Some("same upstream recovered")
+    );
+    assert_eq!(
+        primary_requests.len(),
+        2,
+        "capacity response should retry the same upstream once"
+    );
+    for request in primary_requests {
+        assert_eq!(
+            request.body["model"].as_str(),
+            Some("gpt-5"),
+            "capacity retry must keep the caller-requested model"
+        );
+    }
+}
+
 async fn assert_responses_stream_does_not_fallback_after_first_codex_output() {
     let primary = spawn_mock_raw_upstream(
         StatusCode::OK,
@@ -2005,6 +2179,92 @@ data: [DONE]\n\n",
     assert_eq!(primary_requests.len(), 1);
     assert_eq!(primary_requests[0].path, CODEX_RESPONSES_PATH);
     assert_eq!(fallback_requests.len(), 0);
+}
+
+async fn assert_responses_stream_does_not_retry_same_upstream_after_first_output_capacity_error() {
+    let primary = spawn_mock_raw_sequence_upstream(vec![
+        (
+            StatusCode::OK,
+            Bytes::from(
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial before capacity\"}\n\n\
+data: {\"type\":\"error\",\"error\":{\"message\":\"Selected model is at capacity. Please try a different model.\"}}\n\n",
+            ),
+            "text/event-stream",
+        ),
+        (
+            StatusCode::OK,
+            Bytes::from(
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"second attempt should not run\"}\n\n\
+data: [DONE]\n\n",
+            ),
+            "text/event-stream",
+        ),
+    ])
+    .await;
+    let fallback = spawn_mock_raw_upstream(
+        StatusCode::OK,
+        Bytes::from(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"fallback should not run\"}\n\n\
+data: [DONE]\n\n",
+        ),
+        "text/event-stream",
+    )
+    .await;
+
+    let config = config_with_runtime_upstreams(&[
+        (
+            PROVIDER_CODEX,
+            10,
+            "codex-capacity-after-output",
+            primary.base_url.as_str(),
+            FORMATS_RESPONSES,
+        ),
+        (
+            PROVIDER_RESPONSES,
+            5,
+            "responses-capacity-after-output-fallback",
+            fallback.base_url.as_str(),
+            FORMATS_RESPONSES,
+        ),
+    ]);
+    let data_dir = next_test_data_dir("responses_capacity_after_output_no_same_retry");
+    let state = build_test_state_handle(config, data_dir.clone()).await;
+
+    let response = proxy_request(
+        State(state),
+        Method::POST,
+        Uri::from_static(RESPONSES_PATH),
+        axum::http::HeaderMap::new(),
+        Body::from(
+            json!({
+                "model": "gpt-5",
+                "input": "hi",
+                "stream": true
+            })
+            .to_string(),
+        ),
+    )
+    .await;
+
+    let response_status = response.status();
+    let response_bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("proxy stream response bytes");
+    let response_text = String::from_utf8(response_bytes.to_vec()).expect("response text");
+    let primary_requests = primary.requests();
+    let fallback_requests = fallback.requests();
+
+    primary.abort();
+    fallback.abort();
+    let _ = std::fs::remove_dir_all(&data_dir);
+
+    assert_eq!(response_status, StatusCode::OK);
+    assert!(response_text.contains("partial before capacity"));
+    assert!(response_text.contains("Selected model is at capacity"));
+    assert!(!response_text.contains("second attempt should not run"));
+    assert!(!response_text.contains("fallback should not run"));
+    assert_eq!(primary_requests.len(), 1);
+    assert!(fallback_requests.is_empty());
 }
 
 async fn send_responses_request(state: ProxyStateHandle) -> (StatusCode, Value) {
@@ -4108,6 +4368,13 @@ fn responses_stream_request_falls_back_from_codex_when_created_then_failed_befor
 }
 
 #[test]
+fn responses_request_retries_same_upstream_once_after_capacity_error() {
+    run_async(async {
+        assert_responses_request_retries_same_upstream_once_after_capacity_error().await;
+    });
+}
+
+#[test]
 fn responses_stream_request_falls_back_from_codex_when_headers_timeout_before_output() {
     run_async(async {
         assert_responses_stream_fallbacks_after_pre_header_timeout().await;
@@ -4125,6 +4392,14 @@ fn responses_stream_request_falls_back_when_first_output_deadline_expires_after_
 fn responses_stream_request_does_not_fallback_after_first_codex_output() {
     run_async(async {
         assert_responses_stream_does_not_fallback_after_first_codex_output().await;
+    });
+}
+
+#[test]
+fn responses_stream_request_does_not_retry_same_upstream_after_first_output_capacity_error() {
+    run_async(async {
+        assert_responses_stream_does_not_retry_same_upstream_after_first_output_capacity_error()
+            .await;
     });
 }
 

--- a/crates/token_proxy_core/src/proxy/upstream/dispatch.rs
+++ b/crates/token_proxy_core/src/proxy/upstream/dispatch.rs
@@ -122,6 +122,7 @@ fn apply_attempt_outcome(result: &mut GroupAttemptResult, outcome: AttemptOutcom
             response,
             is_timeout,
             should_cooldown: _,
+            retry_same_upstream_once: _,
         } => {
             if is_timeout {
                 result.last_timeout_error = Some(message.clone());
@@ -342,6 +343,7 @@ async fn dispatch_group_upstreams(
     let mut result = GroupAttemptResult::new();
     let mut in_flight: FuturesUnordered<GroupAttemptFuture<'_>> = FuturesUnordered::new();
     let mut next_to_launch = 0usize;
+    let mut retried_same_upstreams = Vec::new();
 
     launch_group_attempts(
         &mut in_flight,
@@ -435,7 +437,48 @@ async fn dispatch_group_upstreams(
 
         if let Some((item_index, outcome)) = completed {
             let upstream = &items[item_index];
-            if apply_group_attempt_outcome(
+            if should_retry_same_upstream_once(&outcome)
+                && !retried_same_upstreams.contains(&item_index)
+            {
+                retried_same_upstreams.push(item_index);
+                if apply_group_attempt_outcome(
+                    state,
+                    provider,
+                    upstream,
+                    &mut result,
+                    outcome,
+                    cooldown_scope,
+                ) {
+                    return result;
+                }
+                let retry_outcome = retry_same_upstream_once(
+                    state,
+                    &method,
+                    provider,
+                    upstream,
+                    inbound_path,
+                    upstream_path_with_query,
+                    headers,
+                    body,
+                    meta,
+                    request_auth,
+                    client_gemini_api_key,
+                    response_transform,
+                    &request_detail,
+                    cooldown_scope,
+                )
+                .await;
+                if apply_group_attempt_outcome(
+                    state,
+                    provider,
+                    upstream,
+                    &mut result,
+                    retry_outcome,
+                    cooldown_scope,
+                ) {
+                    return result;
+                }
+            } else if apply_group_attempt_outcome(
                 state,
                 provider,
                 upstream,
@@ -481,6 +524,56 @@ async fn dispatch_group_upstreams(
     }
 
     result
+}
+
+fn should_retry_same_upstream_once(outcome: &AttemptOutcome) -> bool {
+    matches!(
+        outcome,
+        AttemptOutcome::Retryable {
+            retry_same_upstream_once: true,
+            ..
+        }
+    )
+}
+
+async fn retry_same_upstream_once(
+    state: &ProxyState,
+    method: &Method,
+    provider: &str,
+    upstream: &UpstreamRuntime,
+    inbound_path: &str,
+    upstream_path_with_query: &str,
+    headers: &HeaderMap,
+    body: &ReplayableBody,
+    meta: &RequestMeta,
+    request_auth: &RequestAuth,
+    client_gemini_api_key: Option<&str>,
+    response_transform: FormatTransform,
+    request_detail: &Option<RequestDetailSnapshot>,
+    cooldown_scope: &CooldownScope,
+) -> AttemptOutcome {
+    tracing::info!(
+        provider,
+        upstream = %upstream.id,
+        "retrying same upstream once after transient capacity response"
+    );
+    attempt::attempt_upstream(
+        state,
+        method.clone(),
+        provider,
+        upstream,
+        inbound_path,
+        upstream_path_with_query,
+        headers,
+        body,
+        meta,
+        request_auth,
+        client_gemini_api_key,
+        response_transform,
+        request_detail.clone(),
+        cooldown_scope,
+    )
+    .await
 }
 
 fn launch_group_attempts<'a>(

--- a/crates/token_proxy_core/src/proxy/upstream/kiro.rs
+++ b/crates/token_proxy_core/src/proxy/upstream/kiro.rs
@@ -317,6 +317,7 @@ fn into_group_retryable_kiro_outcome(outcome: AttemptOutcome) -> AttemptOutcome 
                 response: Some(response),
                 is_timeout: false,
                 should_cooldown: super::result::should_cooldown_retryable_status(status),
+                retry_same_upstream_once: false,
             }
         }
         other => other,

--- a/crates/token_proxy_core/src/proxy/upstream/kiro_http.rs
+++ b/crates/token_proxy_core/src/proxy/upstream/kiro_http.rs
@@ -153,6 +153,7 @@ pub(super) async fn handle_send_error(
                 response: None,
                 is_timeout: true,
                 should_cooldown: true,
+                retry_same_upstream_once: false,
             }
         }
     }

--- a/crates/token_proxy_core/src/proxy/upstream/mod.rs
+++ b/crates/token_proxy_core/src/proxy/upstream/mod.rs
@@ -134,6 +134,7 @@ enum AttemptOutcome {
         response: Option<Response>,
         is_timeout: bool,
         should_cooldown: bool,
+        retry_same_upstream_once: bool,
     },
     Fatal(Response),
     SkippedAuth,

--- a/crates/token_proxy_core/src/proxy/upstream/prepare.rs
+++ b/crates/token_proxy_core/src/proxy/upstream/prepare.rs
@@ -232,6 +232,7 @@ fn codex_account_resolution_outcome(has_pinned_account: bool, err: String) -> At
         response: Some(response),
         is_timeout: false,
         should_cooldown: false,
+        retry_same_upstream_once: false,
     }
 }
 

--- a/crates/token_proxy_core/src/proxy/upstream/result.rs
+++ b/crates/token_proxy_core/src/proxy/upstream/result.rs
@@ -94,11 +94,23 @@ pub(super) async fn handle_upstream_result(
             {
                 return AttemptOutcome::Success(response);
             }
+            let retryable_response = response
+                .extensions()
+                .get::<RetryableStreamResponse>()
+                .cloned();
+            let retry_same_upstream_once = retryable_response
+                .as_ref()
+                .is_some_and(|retryable| retryable.retry_same_upstream_once);
+            let should_cooldown = retryable_response.as_ref().map_or_else(
+                || should_cooldown_retryable_status(status),
+                |retryable| retryable.should_cooldown,
+            );
             AttemptOutcome::Retryable {
                 message: format!("Upstream responded with {}", response.status()),
                 response: Some(response),
                 is_timeout: false,
-                should_cooldown: should_cooldown_retryable_status(status),
+                should_cooldown,
+                retry_same_upstream_once,
             }
         }
         Ok(res) => {
@@ -140,6 +152,7 @@ pub(super) async fn handle_upstream_result(
                     response: Some(response),
                     is_timeout: false,
                     should_cooldown: retryable.should_cooldown,
+                    retry_same_upstream_once: retryable.retry_same_upstream_once,
                 };
             }
             update_account_cooldown_from_status(
@@ -183,6 +196,7 @@ pub(super) async fn handle_upstream_result(
                 response: None,
                 is_timeout: err.is_timeout(),
                 should_cooldown: true,
+                retry_same_upstream_once: false,
             }
         }
         Err(err) => {

--- a/crates/token_proxy_core/src/proxy/upstream/transport.rs
+++ b/crates/token_proxy_core/src/proxy/upstream/transport.rs
@@ -532,6 +532,7 @@ fn handle_upstream_timeout(
         response: None,
         is_timeout: true,
         should_cooldown: true,
+        retry_same_upstream_once: false,
     }
 }
 
@@ -578,6 +579,7 @@ fn map_upstream_error(
             response: None,
             is_timeout: err.is_timeout(),
             should_cooldown: true,
+            retry_same_upstream_once: false,
         };
     }
     let error_message = format!("Upstream request failed: {message}");


### PR DESCRIPTION
## Summary
- retry transient capacity errors on the same upstream once before continuing failover
- keep the caller-requested model unchanged even when the upstream says to try a different model
- keep stream safety boundary: no retry/fallback after client output starts

## Verification
- cargo test -p token_proxy_core capacity -- --nocapture
- cargo test -p token_proxy_core responses_stream_request_ -- --nocapture
- cargo test -p token_proxy_core
- cargo fmt --check
- git diff --check