### PR TITLE
fix(proxy): promote additional_tools input items for openai-response upstreams

### DIFF
--- a/crates/token_proxy_runtime/src/proxy/upstream/request_body.rs
+++ b/crates/token_proxy_runtime/src/proxy/upstream/request_body.rs
@@ -83,7 +83,7 @@ pub(super) async fn xai_client_tool_mapping(
     let Some(object) = value.as_object_mut() else {
         return Ok(None);
     };
-    promote_xai_additional_tools(object);
+    promote_additional_tools(object);
     let (mut mapping, _) =
         token_proxy_protocol::xai_client_tools::adapt_request(object).map_err(|message| {
             AttemptOutcome::Fatal(http::error_response(StatusCode::BAD_REQUEST, message))
@@ -209,6 +209,13 @@ async fn build_json_transformed_body_with_headers(
         body_len,
         filter_limit_bytes,
     );
+    changed |= promote_openai_response_additional_tools(
+        provider,
+        upstream_path,
+        object,
+        body_len,
+        filter_limit_bytes,
+    );
     changed |= filter_xai_responses_request(
         provider,
         upstream_path,
@@ -278,6 +285,7 @@ fn json_transform_read_limit(
     if should_apply_reasoning_effort(provider, upstream_path, meta)
         || should_filter_openai_responses_fields(provider, upstream, upstream_path)
         || should_sanitize_native_openai_responses_input(provider, upstream_path)
+        || should_promote_openai_response_additional_tools(provider, upstream_path)
         || should_filter_xai_responses_request(provider, upstream_path)
         || should_normalize_xai_image_refs(provider)
         || should_strip_openai_responses_sampling_params(provider, upstream_path, meta)
@@ -304,6 +312,7 @@ fn needs_json_transform(
         || should_apply_reasoning_effort(provider, upstream_path, meta)
         || should_filter_openai_responses_fields(provider, upstream, upstream_path)
         || should_sanitize_native_openai_responses_input(provider, upstream_path)
+        || should_promote_openai_response_additional_tools(provider, upstream_path)
         || should_filter_xai_responses_request(provider, upstream_path)
         || should_normalize_xai_image_refs(provider)
         || should_strip_openai_responses_sampling_params(provider, upstream_path, meta)
@@ -549,6 +558,27 @@ fn should_sanitize_native_openai_responses_input(provider: &str, upstream_path: 
     matches!(provider, "openai" | "openai-response") && upstream_path == OPENAI_RESPONSES_PATH
 }
 
+// Third-party Responses upstreams (sglang、vLLM 等) 的 input 类型校验是严格白名单，
+// 会把 Codex 的 `additional_tools` input item 直接 400。声明改放根 tools 是等价写法。
+fn should_promote_openai_response_additional_tools(provider: &str, upstream_path: &str) -> bool {
+    provider == "openai-response" && upstream_path == OPENAI_RESPONSES_PATH
+}
+
+fn promote_openai_response_additional_tools(
+    provider: &str,
+    upstream_path: &str,
+    object: &mut Map<String, Value>,
+    body_len: usize,
+    filter_limit_bytes: usize,
+) -> bool {
+    if body_len > filter_limit_bytes
+        || !should_promote_openai_response_additional_tools(provider, upstream_path)
+    {
+        return false;
+    }
+    promote_additional_tools(object)
+}
+
 /// 删除上游不接受的客户端历史元数据；只处理 direct input item，不触碰 tools 或嵌套 content。
 fn sanitize_native_openai_responses_input(
     provider: &str,
@@ -661,7 +691,7 @@ fn filter_xai_responses_request(
         );
     }
 
-    changed |= promote_xai_additional_tools(object);
+    changed |= promote_additional_tools(object);
     let (_, client_tools_changed) = token_proxy_protocol::xai_client_tools::adapt_request(object)
         .map_err(|message| {
         AttemptOutcome::Fatal(http::error_response(StatusCode::BAD_REQUEST, message))
@@ -736,9 +766,10 @@ fn is_xai_native_x_search_tool(tool: &Value) -> bool {
         .is_some_and(|tool_type| tool_type.trim() == "x_search")
 }
 
-// Responses Lite encodes extra declarations as input items, while xAI accepts
-// declarations only in the root tools array. Preserve root order, then append extras.
-fn promote_xai_additional_tools(object: &mut Map<String, Value>) -> bool {
+// Responses Lite encodes extra declarations as input items, while upstreams such as
+// xAI and sglang accept declarations only in the root tools array. Preserve root
+// order, then append extras, skipping tools that already share the same name.
+fn promote_additional_tools(object: &mut Map<String, Value>) -> bool {
     let Some(input) = object.get_mut("input").and_then(Value::as_array_mut) else {
         return false;
     };
@@ -760,13 +791,26 @@ fn promote_xai_additional_tools(object: &mut Map<String, Value>) -> bool {
 
     if !promoted.is_empty() {
         match object.get_mut("tools") {
-            Some(Value::Array(tools)) => tools.extend(promoted),
+            Some(Value::Array(tools)) => {
+                for tool in promoted {
+                    let name = tool.get("name").and_then(Value::as_str).map(str::trim);
+                    let duplicate = name.is_some_and(|name| {
+                        tools.iter().any(|existing| {
+                            existing.get("name").and_then(Value::as_str).map(str::trim)
+                                == Some(name)
+                        })
+                    });
+                    if !duplicate {
+                        tools.push(tool);
+                    }
+                }
+            }
             _ => {
                 object.insert("tools".to_string(), Value::Array(promoted));
             }
         }
     }
-    tracing::debug!("promoted xAI additional_tools into root tools");
+    tracing::debug!("promoted additional_tools input items into root tools");
     true
 }
 

--- a/crates/token_proxy_runtime/src/proxy/upstream/request_body.test.rs
+++ b/crates/token_proxy_runtime/src/proxy/upstream/request_body.test.rs
@@ -68,6 +68,72 @@ async fn transformed_xai_body(path: &str, body: &'static [u8], model: &str) -> V
     serde_json::from_slice(&bytes).expect("transformed JSON")
 }
 
+async fn transformed_openai_response_body(provider: &str, body: &[u8]) -> Option<Value> {
+    let upstream = test_upstream(false, false, false);
+    let body = ReplayableBody::from_bytes(Bytes::copy_from_slice(body));
+    let rewritten = match build_json_transformed_body(
+        provider,
+        &upstream,
+        "/v1/responses",
+        &body,
+        &xai_meta("gpt-4o", true),
+        None,
+    )
+    .await
+    {
+        Ok(value) => value,
+        Err(_) => panic!("transform should succeed"),
+    };
+    let Some(rewritten) = rewritten else {
+        return None;
+    };
+    let bytes = rewritten
+        .read_bytes_if_small(4096)
+        .await
+        .expect("read transformed body")
+        .expect("transformed bytes");
+    Some(serde_json::from_slice(&bytes).expect("transformed JSON"))
+}
+
+#[tokio::test]
+async fn openai_response_promotes_additional_tools_into_root_tools() {
+    let value = transformed_openai_response_body(
+        "openai-response",
+        br#"{"model":"qwen","input":[{"type":"message","role":"user","content":"hi"},{"type":"additional_tools","role":"developer","tools":[{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}]}]}"#,
+    )
+    .await
+    .expect("body should change");
+
+    assert_eq!(value["input"].as_array().map(Vec::len), Some(1));
+    assert_eq!(value["input"][0]["type"], "message");
+    assert_eq!(value["tools"][0]["type"], "namespace");
+    assert_eq!(value["tools"][0]["name"], "functions");
+}
+
+#[tokio::test]
+async fn openai_response_promotion_skips_duplicate_tool_names() {
+    let value = transformed_openai_response_body(
+        "openai-response",
+        br#"{"model":"qwen","tools":[{"type":"custom","name":"exec"}],"input":[{"type":"additional_tools","tools":[{"type":"custom","name":"exec"},{"type":"function","name":"Bash"}]}]}"#,
+    )
+    .await
+    .expect("body should change");
+
+    assert_eq!(value["tools"].as_array().map(Vec::len), Some(2));
+    assert_eq!(value["tools"][1]["name"], "Bash");
+}
+
+#[tokio::test]
+async fn native_openai_keeps_additional_tools_input_items() {
+    let value = transformed_openai_response_body(
+        "openai",
+        br#"{"model":"gpt-5","input":[{"type":"additional_tools","tools":[{"type":"custom","name":"exec"}]}]}"#,
+    )
+    .await;
+
+    assert!(value.is_none(), "native OpenAI input should pass through");
+}
+
 async fn transformed_body_with_x_search(
     provider: &str,
     path: &str,


### PR DESCRIPTION
## 问题

Closes #307

Codex CLI 0.150.x 将内置 code-mode `exec` 工具以 Responses API 的 `additional_tools` input item 混在 `input` 中发送（首次请求即包含，且无配置可关闭）。sglang / vLLM 等第三方 Responses 上游对 input 类型做严格白名单校验，直接返回：

```json
{"error":{"code":"invalid_request_error","message":"Unsupported Responses API input item type: 'additional_tools' None"}}
```

导致 Codex 完全无法经由 openai-response 上游使用。

## 方案

xAI 上游已有相同的处理（`promote_xai_additional_tools`）：把 `additional_tools` 里的工具声明提升到根 `tools` 数组，再删除该 input item。本 PR 将其泛化为 `promote_additional_tools` 并同样应用到 `openai-response` provider 的 `/v1/responses`：

- 提升时按工具名去重，避免多轮历史重复注入同名工具
- 原生 `openai` provider 保持透传不变（官方 Responses API 接受该 item，且 Responses Lite 依赖 input 内声明）
- 复用现有 `filter_limit_bytes` 体量上限，与其余改写一致

## 测试

`cargo test -p token_proxy_runtime` 640 passed，新增 3 个用例：

- `openai_response_promotes_additional_tools_into_root_tools`
- `openai_response_promotion_skips_duplicate_tool_names`
- `native_openai_keeps_additional_tools_input_items`（守护原生透传）

本地实测 Codex CLI 0.150.1 → token_proxy → sglang 上游，修复后请求正常返回。